### PR TITLE
feat: 新增本地 WebSocket 广播接口

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -813,6 +813,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5161,6 +5167,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "crc32fast",
+ "futures-util",
  "image",
  "rfd",
  "serde",
@@ -5174,6 +5181,7 @@ dependencies = [
  "tauri-plugin-sql",
  "tauri-plugin-updater",
  "tokio",
+ "tokio-tungstenite",
  "windows 0.62.2",
  "zip",
 ]
@@ -5214,7 +5222,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5236,6 +5256,18 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -5460,6 +5492,23 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,11 +25,13 @@ tauri-plugin-autostart = "2"
 tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+futures-util = "0.3"
 windows = { version = "0.62.2", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading", "Win32_UI_Input_KeyboardAndMouse", "Win32_Graphics_Gdi", "Win32_UI_Shell", "Win32_UI_Shell_PropertiesSystem", "Win32_System_ProcessStatus", "Win32_System_SystemInformation", "Win32_System_Diagnostics_ToolHelp", "Win32_System_RemoteDesktop", "Win32_System_LibraryLoader", "Win32_System_Com", "Win32_System_Com_StructuredStorage", "Win32_System_Variant", "Win32_Storage_FileSystem", "Win32_Media_Audio", "Media", "Media_Control"] }
 image = "0.24"
 base64 = "0.22.1"
 chrono = "0.4.44"
-tokio = { version = "1.50.0", features = ["rt-multi-thread", "time"] }
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "time", "net", "sync", "macros"] }
+tokio-tungstenite = "0.28"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio"] }
 rfd = "0.15.4"

--- a/src-tauri/src/app/backup.rs
+++ b/src-tauri/src/app/backup.rs
@@ -1,7 +1,7 @@
 use crate::app::desktop_behavior;
 use crate::data::backup::{self, RestoreStrategy};
 use crate::engine::tracking::runtime as tracking_runtime;
-use tauri::AppHandle;
+use tauri::{AppHandle, Emitter};
 
 pub(crate) async fn restore_backup_and_refresh(
     app: AppHandle,
@@ -10,6 +10,8 @@ pub(crate) async fn restore_backup_and_refresh(
 ) -> Result<(), String> {
     backup::restore_backup(backup_path, app.clone(), strategy).await?;
     desktop_behavior::sync_desktop_behavior_from_storage(app.clone(), false).await?;
+    app.emit("app-settings-changed", serde_json::json!({}))
+        .map_err(|error| format!("failed to emit settings refresh event: {error}"))?;
     tracking_runtime::emit_tracking_data_changed(&app, "backup-restored", now_ms())
         .map_err(|error| format!("failed to emit restore refresh event: {error}"))?;
     Ok(())

--- a/src-tauri/src/app/bootstrap.rs
+++ b/src-tauri/src/app/bootstrap.rs
@@ -43,6 +43,7 @@ fn register_managed_state_and_plugins(
         .manage(DesktopBehaviorState::default())
         .manage(AppExitState::default())
         .manage(WidgetWindowLifecycleState::default())
+        .manage(crate::platform::local_api::LocalApiRuntimeState::default())
         .manage(UpdaterRuntimeState::new(app_version.to_string()))
         .plugin(
             tauri_plugin_autostart::Builder::new()

--- a/src-tauri/src/app/local_api.rs
+++ b/src-tauri/src/app/local_api.rs
@@ -1,0 +1,128 @@
+use crate::commands::tracking::CurrentTrackingSnapshot;
+use crate::data::repositories::app_settings;
+use crate::data::sqlite_pool::wait_for_sqlite_pool;
+use crate::data::tracking_runtime::TrackingRuntimeDataStore;
+use crate::domain::settings::LocalApiSettings;
+use crate::engine::tracking::runtime::load_current_tracking_snapshot;
+use crate::platform::local_api::{
+    self, LocalApiRuntimeDeps, LocalApiRuntimeState, LOCAL_API_ACTIVE_WINDOW_EVENT,
+    LOCAL_API_SETTINGS_CHANGED_EVENT, LOCAL_API_TRACKING_DATA_EVENT,
+};
+use serde_json::Value;
+use std::future::Future;
+use std::pin::Pin;
+use tauri::{AppHandle, Listener, Manager, Runtime};
+
+pub fn start<R: Runtime + 'static>(app: AppHandle<R>) {
+    if app.try_state::<LocalApiRuntimeState>().is_none() {
+        eprintln!("[local-api] runtime state is not available");
+        return;
+    }
+
+    spawn_settings_bootstrap(app.clone());
+    register_event_forwarders(app);
+}
+
+fn spawn_settings_bootstrap<R: Runtime + 'static>(app: AppHandle<R>) {
+    tauri::async_runtime::spawn(async move {
+        match load_local_api_settings(&app).await {
+            Ok(settings) => update_runtime_state(app, settings),
+            Err(error) => eprintln!("[local-api] failed to load settings: {error}"),
+        }
+    });
+}
+
+fn register_event_forwarders<R: Runtime + 'static>(app: AppHandle<R>) {
+    let settings_app = app.clone();
+    app.listen_any(LOCAL_API_SETTINGS_CHANGED_EVENT, move |_| {
+        let settings_app = settings_app.clone();
+        tauri::async_runtime::spawn(async move {
+            match load_local_api_settings(&settings_app).await {
+                Ok(settings) => update_runtime_state(settings_app, settings),
+                Err(error) => eprintln!("[local-api] failed to reload settings: {error}"),
+            }
+        });
+    });
+
+    let active_window_app = app.clone();
+    app.listen_any(LOCAL_API_ACTIVE_WINDOW_EVENT, move |event| {
+        broadcast_event(
+            &active_window_app,
+            LOCAL_API_ACTIVE_WINDOW_EVENT,
+            event.payload(),
+        );
+    });
+
+    let tracking_data_app = app.clone();
+    app.listen_any(LOCAL_API_TRACKING_DATA_EVENT, move |event| {
+        broadcast_event(
+            &tracking_data_app,
+            LOCAL_API_TRACKING_DATA_EVENT,
+            event.payload(),
+        );
+    });
+}
+
+fn update_runtime_state<R: Runtime + 'static>(app: AppHandle<R>, settings: LocalApiSettings) {
+    if let Some(state) = app.try_state::<LocalApiRuntimeState>() {
+        state.update(
+            app.clone(),
+            settings,
+            LocalApiRuntimeDeps {
+                load_token: load_current_token_boxed::<R>,
+                load_snapshot: load_snapshot_message_boxed::<R>,
+            },
+        );
+    }
+}
+
+fn broadcast_event<R: Runtime>(app: &AppHandle<R>, event_type: &str, payload: &str) {
+    if let Some(state) = app.try_state::<LocalApiRuntimeState>() {
+        state.broadcast(local_api::message_json(
+            event_type,
+            serde_json::from_str(payload).unwrap_or(Value::Null),
+        ));
+    }
+}
+
+async fn load_local_api_settings<R: Runtime>(
+    app: &AppHandle<R>,
+) -> Result<LocalApiSettings, String> {
+    let pool = wait_for_sqlite_pool(app).await?;
+    app_settings::load_local_api_settings(&pool)
+        .await
+        .map_err(|error| format!("failed to load local api settings: {error}"))
+}
+
+async fn load_current_token<R: Runtime>(app: AppHandle<R>) -> Option<String> {
+    load_local_api_settings(&app)
+        .await
+        .ok()
+        .map(|settings| settings.token)
+}
+
+fn load_current_token_boxed<R: Runtime + 'static>(
+    app: AppHandle<R>,
+) -> Pin<Box<dyn Future<Output = Option<String>> + Send>> {
+    Box::pin(load_current_token(app))
+}
+
+async fn load_snapshot_message<R: Runtime>(app: AppHandle<R>) -> Option<String> {
+    let pool = wait_for_sqlite_pool(&app).await.ok()?;
+    let data = TrackingRuntimeDataStore::new(pool);
+    let snapshot = load_current_tracking_snapshot(&data).await.ok()?;
+    let payload = CurrentTrackingSnapshot {
+        window: snapshot.window,
+        status: snapshot.status,
+    };
+    Some(local_api::message_json(
+        "snapshot",
+        serde_json::to_value(payload).unwrap_or(Value::Null),
+    ))
+}
+
+fn load_snapshot_message_boxed<R: Runtime + 'static>(
+    app: AppHandle<R>,
+) -> Pin<Box<dyn Future<Output = Option<String>> + Send>> {
+    Box::pin(load_snapshot_message(app))
+}

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -1,6 +1,7 @@
 pub mod backup;
 pub mod bootstrap;
 pub mod desktop_behavior;
+pub mod local_api;
 pub mod runtime;
 pub mod runtime_tasks;
 pub mod state;

--- a/src-tauri/src/app/runtime.rs
+++ b/src-tauri/src/app/runtime.rs
@@ -52,6 +52,7 @@ pub fn setup(
     power::start(app.handle().clone());
     audio::start_signal_source();
     media::start_signal_source();
+    crate::app::local_api::start(app.handle().clone());
 
     let app_handle = app.handle().clone();
     setup_tray(&app_handle)?;

--- a/src-tauri/src/data/repositories/app_settings.rs
+++ b/src-tauri/src/data/repositories/app_settings.rs
@@ -1,10 +1,13 @@
-use crate::domain::settings::DesktopBehaviorSettings;
+use crate::domain::settings::{DesktopBehaviorSettings, LocalApiSettings};
 use sqlx::{Pool, Row, Sqlite};
 
 const CLOSE_BEHAVIOR_KEY: &str = "close_behavior";
 const MINIMIZE_BEHAVIOR_KEY: &str = "minimize_behavior";
 const LAUNCH_AT_LOGIN_KEY: &str = "launch_at_login";
 const START_MINIMIZED_KEY: &str = "start_minimized";
+const LOCAL_API_ENABLED_KEY: &str = "local_api_enabled";
+const LOCAL_API_PORT_KEY: &str = "local_api_port";
+const LOCAL_API_TOKEN_KEY: &str = "local_api_token";
 const MAX_APP_SETTING_VALUE_LEN: usize = 4096;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -122,7 +125,41 @@ fn is_allowed_app_setting_key(key: &str) -> bool {
             | "launch_at_login"
             | "start_minimized"
             | "onboarding_completed"
+            | "local_api_enabled"
+            | "local_api_port"
+            | "local_api_token"
     )
+}
+
+pub async fn load_local_api_settings(pool: &Pool<Sqlite>) -> Result<LocalApiSettings, sqlx::Error> {
+    let rows = sqlx::query("SELECT key, value FROM settings WHERE key IN (?, ?, ?)")
+        .bind(LOCAL_API_ENABLED_KEY)
+        .bind(LOCAL_API_PORT_KEY)
+        .bind(LOCAL_API_TOKEN_KEY)
+        .fetch_all(pool)
+        .await?;
+
+    let mut enabled: Option<String> = None;
+    let mut port: Option<String> = None;
+    let mut token: Option<String> = None;
+
+    for row in rows {
+        let key: String = row.get("key");
+        let value: String = row.get("value");
+
+        match key.as_str() {
+            LOCAL_API_ENABLED_KEY => enabled = Some(value),
+            LOCAL_API_PORT_KEY => port = Some(value),
+            LOCAL_API_TOKEN_KEY => token = Some(value),
+            _ => {}
+        }
+    }
+
+    Ok(LocalApiSettings::from_storage_values(
+        enabled.as_deref(),
+        port.as_deref(),
+        token.as_deref(),
+    ))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/data/repositories/sessions.rs
+++ b/src-tauri/src/data/repositories/sessions.rs
@@ -295,14 +295,24 @@ pub async fn start_session(
     continuity_group_start_time: i64,
 ) -> Result<bool, sqlx::Error> {
     if let Some(existing_session) = load_active_session(pool).await? {
-        if existing_session.exe_name.eq_ignore_ascii_case(exe_name)
-            && existing_session.window_title == window_title
-        {
-            return Ok(false);
-        }
+        let _ = (&existing_session.exe_name, &existing_session.window_title);
+        return Ok(false);
     }
 
     let mut tx = pool.begin().await?;
+    let active_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM sessions
+         WHERE end_time IS NULL",
+    )
+    .fetch_one(&mut *tx)
+    .await?;
+
+    if active_count > 0 {
+        tx.rollback().await?;
+        return Ok(false);
+    }
+
     let result = sqlx::query(
         "INSERT INTO sessions (
             app_name,
@@ -318,7 +328,18 @@ pub async fn start_session(
     .bind(start_time)
     .bind(continuity_group_start_time)
     .execute(&mut *tx)
-    .await?;
+    .await;
+
+    let result = match result {
+        Ok(result) => result,
+        Err(error) => {
+            if is_single_active_session_conflict(&error) {
+                tx.rollback().await?;
+                return Ok(false);
+            }
+            return Err(error);
+        }
+    };
     let session_id = result.last_insert_rowid();
 
     session_title_samples::start_title_sample_tx(&mut tx, session_id, window_title, start_time)
@@ -326,4 +347,125 @@ pub async fn start_session(
 
     tx.commit().await?;
     Ok(true)
+}
+
+fn is_single_active_session_conflict(error: &sqlx::Error) -> bool {
+    let sqlx::Error::Database(error) = error else {
+        return false;
+    };
+
+    if error.constraint() == Some("idx_sessions_single_active") {
+        return true;
+    }
+
+    error.message().contains("idx_sessions_single_active")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::schema as db_schema;
+    use sqlx::{Executor, SqlitePool};
+
+    async fn setup_test_db() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        pool.execute(db_schema::CURRENT_BASELINE_SCHEMA_SQL)
+            .await
+            .unwrap();
+        pool
+    }
+
+    #[test]
+    fn start_session_is_noop_when_any_active_session_exists() {
+        tauri::async_runtime::block_on(async {
+            let pool = setup_test_db().await;
+
+            assert!(
+                start_session(&pool, "Code", "Code.exe", "Editor", 1_000, 1_000)
+                    .await
+                    .unwrap()
+            );
+            assert!(
+                !start_session(&pool, "Edge", "msedge.exe", "Browser", 2_000, 2_000)
+                    .await
+                    .unwrap()
+            );
+
+            let active_count: i64 =
+                sqlx::query_scalar("SELECT COUNT(*) FROM sessions WHERE end_time IS NULL")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            let first_session: (String, String) =
+                sqlx::query_as("SELECT exe_name, window_title FROM sessions LIMIT 1")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+
+            assert_eq!(active_count, 1);
+            assert_eq!(
+                first_session,
+                ("Code.exe".to_string(), "Editor".to_string())
+            );
+        });
+    }
+
+    #[test]
+    fn start_session_treats_single_active_index_conflict_as_noop() {
+        tauri::async_runtime::block_on(async {
+            let pool = setup_test_db().await;
+            let mut tx = pool.begin().await.unwrap();
+
+            let result = sqlx::query(
+                "INSERT INTO sessions (
+                    app_name,
+                    exe_name,
+                    window_title,
+                    start_time,
+                    continuity_group_start_time
+                 ) VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind("Code")
+            .bind("Code.exe")
+            .bind("Editor")
+            .bind(1_000)
+            .bind(1_000)
+            .execute(&mut *tx)
+            .await
+            .unwrap();
+            let session_id = result.last_insert_rowid();
+
+            let insert = sqlx::query(
+                "INSERT INTO sessions (
+                    app_name,
+                    exe_name,
+                    window_title,
+                    start_time,
+                    continuity_group_start_time
+                 ) VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind("Edge")
+            .bind("msedge.exe")
+            .bind("Browser")
+            .bind(2_000)
+            .bind(2_000)
+            .execute(&mut *tx)
+            .await;
+
+            assert!(insert
+                .as_ref()
+                .err()
+                .is_some_and(is_single_active_session_conflict));
+            tx.rollback().await.unwrap();
+
+            let active: Option<i64> =
+                sqlx::query_scalar("SELECT id FROM sessions WHERE end_time IS NULL")
+                    .fetch_optional(&pool)
+                    .await
+                    .unwrap();
+
+            assert_eq!(active, None);
+            assert!(session_id > 0);
+        });
+    }
 }

--- a/src-tauri/src/domain/settings.rs
+++ b/src-tauri/src/domain/settings.rs
@@ -54,14 +54,18 @@ impl LocalApiSettings {
         port: Option<&str>,
         token: Option<&str>,
     ) -> Self {
+        let token = token.unwrap_or(DEFAULT_LOCAL_API_TOKEN).trim().to_string();
+        let enabled = enabled
+            .map(|raw| parse_boolean_setting(raw, DEFAULT_LOCAL_API_ENABLED))
+            .unwrap_or(DEFAULT_LOCAL_API_ENABLED)
+            && !token.is_empty();
+
         Self {
-            enabled: enabled
-                .map(|raw| parse_boolean_setting(raw, DEFAULT_LOCAL_API_ENABLED))
-                .unwrap_or(DEFAULT_LOCAL_API_ENABLED),
+            enabled,
             port: port
                 .and_then(parse_local_api_port)
                 .unwrap_or(DEFAULT_LOCAL_API_PORT),
-            token: token.unwrap_or(DEFAULT_LOCAL_API_TOKEN).to_string(),
+            token,
         }
     }
 }
@@ -162,7 +166,9 @@ pub fn parse_boolean_setting(raw: &str, fallback: bool) -> bool {
 
 pub fn parse_local_api_port(raw: &str) -> Option<u16> {
     let port = raw.trim().parse::<u16>().ok()?;
-    (LOCAL_API_PORT_MIN..=u16::MAX).contains(&port).then_some(port)
+    (LOCAL_API_PORT_MIN..=u16::MAX)
+        .contains(&port)
+        .then_some(port)
 }
 
 #[cfg(test)]
@@ -178,7 +184,10 @@ mod tests {
         assert_eq!(parse_close_behavior("tray"), CloseBehavior::Tray);
         assert_eq!(parse_close_behavior("unknown"), CloseBehavior::Exit);
         assert_eq!(parse_minimize_behavior("widget"), MinimizeBehavior::Widget);
-        assert_eq!(parse_minimize_behavior("taskbar"), MinimizeBehavior::Taskbar);
+        assert_eq!(
+            parse_minimize_behavior("taskbar"),
+            MinimizeBehavior::Taskbar
+        );
         assert_eq!(
             parse_minimize_behavior("anything-else"),
             MinimizeBehavior::Widget
@@ -207,6 +216,14 @@ mod tests {
                 enabled: true,
                 port: DEFAULT_LOCAL_API_PORT,
                 token: "secret".to_string(),
+            }
+        );
+        assert_eq!(
+            LocalApiSettings::from_storage_values(Some("1"), Some("18080"), Some("   ")),
+            LocalApiSettings {
+                enabled: false,
+                port: 18_080,
+                token: String::new(),
             }
         );
         assert_eq!(parse_local_api_port("65535"), Some(65_535));

--- a/src-tauri/src/domain/settings.rs
+++ b/src-tauri/src/domain/settings.rs
@@ -2,6 +2,10 @@ use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_LAUNCH_AT_LOGIN: bool = true;
 pub const DEFAULT_START_MINIMIZED: bool = true;
+pub const DEFAULT_LOCAL_API_ENABLED: bool = false;
+pub const DEFAULT_LOCAL_API_PORT: u16 = 17_321;
+pub const DEFAULT_LOCAL_API_TOKEN: &str = "";
+pub const LOCAL_API_PORT_MIN: u16 = 1024;
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -25,6 +29,41 @@ pub struct DesktopBehaviorSettings {
     pub minimize_behavior: MinimizeBehavior,
     pub launch_at_login: bool,
     pub start_minimized: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LocalApiSettings {
+    pub enabled: bool,
+    pub port: u16,
+    pub token: String,
+}
+
+impl Default for LocalApiSettings {
+    fn default() -> Self {
+        Self {
+            enabled: DEFAULT_LOCAL_API_ENABLED,
+            port: DEFAULT_LOCAL_API_PORT,
+            token: DEFAULT_LOCAL_API_TOKEN.to_string(),
+        }
+    }
+}
+
+impl LocalApiSettings {
+    pub fn from_storage_values(
+        enabled: Option<&str>,
+        port: Option<&str>,
+        token: Option<&str>,
+    ) -> Self {
+        Self {
+            enabled: enabled
+                .map(|raw| parse_boolean_setting(raw, DEFAULT_LOCAL_API_ENABLED))
+                .unwrap_or(DEFAULT_LOCAL_API_ENABLED),
+            port: port
+                .and_then(parse_local_api_port)
+                .unwrap_or(DEFAULT_LOCAL_API_PORT),
+            token: token.unwrap_or(DEFAULT_LOCAL_API_TOKEN).to_string(),
+        }
+    }
 }
 
 impl Default for DesktopBehaviorSettings {
@@ -121,12 +160,17 @@ pub fn parse_boolean_setting(raw: &str, fallback: bool) -> bool {
     }
 }
 
+pub fn parse_local_api_port(raw: &str) -> Option<u16> {
+    let port = raw.trim().parse::<u16>().ok()?;
+    (LOCAL_API_PORT_MIN..=u16::MAX).contains(&port).then_some(port)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_boolean_setting, parse_close_behavior, parse_minimize_behavior, CloseBehavior,
-        DesktopBehaviorSettings, MinimizeBehavior, DEFAULT_LAUNCH_AT_LOGIN,
-        DEFAULT_START_MINIMIZED,
+        parse_boolean_setting, parse_close_behavior, parse_local_api_port, parse_minimize_behavior,
+        CloseBehavior, DesktopBehaviorSettings, LocalApiSettings, MinimizeBehavior,
+        DEFAULT_LAUNCH_AT_LOGIN, DEFAULT_LOCAL_API_PORT, DEFAULT_START_MINIMIZED,
     };
 
     #[test]
@@ -149,6 +193,24 @@ mod tests {
         assert!(!parse_boolean_setting("off", true));
         assert!(parse_boolean_setting("invalid", true));
         assert!(!parse_boolean_setting("invalid", false));
+    }
+
+    #[test]
+    fn local_api_settings_parse_defaults_and_invalid_port() {
+        assert_eq!(
+            LocalApiSettings::from_storage_values(None, None, None),
+            LocalApiSettings::default()
+        );
+        assert_eq!(
+            LocalApiSettings::from_storage_values(Some("1"), Some("80"), Some("secret")),
+            LocalApiSettings {
+                enabled: true,
+                port: DEFAULT_LOCAL_API_PORT,
+                token: "secret".to_string(),
+            }
+        );
+        assert_eq!(parse_local_api_port("65535"), Some(65_535));
+        assert_eq!(parse_local_api_port("1023"), None);
     }
 
     #[test]

--- a/src-tauri/src/platform/local_api/mod.rs
+++ b/src-tauri/src/platform/local_api/mod.rs
@@ -1,8 +1,9 @@
 use crate::domain::settings::LocalApiSettings;
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{json, Value};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::future::Future;
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener as StdTcpListener};
 use std::pin::Pin;
 use std::sync::Mutex;
 use tauri::{AppHandle, Runtime};
@@ -78,12 +79,7 @@ impl LocalApiRuntimeState {
         }
 
         if settings.enabled && (should_restart || inner.server_task.is_none()) {
-            inner.server_task = Some(spawn_server(
-                app,
-                self.event_tx.clone(),
-                settings.clone(),
-                deps,
-            ));
+            inner.server_task = spawn_server(app, self.event_tx.clone(), settings.clone(), deps);
         }
 
         inner.settings = settings;
@@ -99,13 +95,23 @@ fn spawn_server<R: Runtime + 'static>(
     event_tx: broadcast::Sender<String>,
     settings: LocalApiSettings,
     deps: LocalApiRuntimeDeps<R>,
-) -> tauri::async_runtime::JoinHandle<()> {
-    tauri::async_runtime::spawn(async move {
-        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), settings.port);
-        let listener = match TcpListener::bind(address).await {
+) -> Option<tauri::async_runtime::JoinHandle<()>> {
+    let (address, std_listener) = match open_local_api_listener(settings.port) {
+        Ok(listener) => listener,
+        Err(error) => {
+            eprintln!(
+                "[local-api] failed to bind 127.0.0.1:{}: {error}",
+                settings.port
+            );
+            return None;
+        }
+    };
+
+    Some(tauri::async_runtime::spawn(async move {
+        let listener = match TcpListener::from_std(std_listener) {
             Ok(listener) => listener,
             Err(error) => {
-                eprintln!("[local-api] failed to bind {address}: {error}");
+                eprintln!("[local-api] failed to attach listener {address}: {error}");
                 return;
             }
         };
@@ -132,7 +138,14 @@ fn spawn_server<R: Runtime + 'static>(
                 }
             });
         }
-    })
+    }))
+}
+
+fn open_local_api_listener(port: u16) -> io::Result<(SocketAddr, StdTcpListener)> {
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    let listener = StdTcpListener::bind(address)?;
+    listener.set_nonblocking(true)?;
+    Ok((address, listener))
 }
 
 async fn handle_client<R: Runtime>(
@@ -282,5 +295,18 @@ mod tests {
 
         let wrong = Message::Text(r#"{"type":"hello","token":"abc"}"#.into());
         assert_eq!(parse_auth_token(&wrong), None);
+    }
+
+    #[test]
+    fn listener_bind_can_recover_after_occupied_port_is_released() {
+        let (_address, occupied_listener) = open_local_api_listener(0).unwrap();
+        let port = occupied_listener.local_addr().unwrap().port();
+
+        assert!(open_local_api_listener(port).is_err());
+
+        drop(occupied_listener);
+
+        let (_address, recovered_listener) = open_local_api_listener(port).unwrap();
+        assert_eq!(recovered_listener.local_addr().unwrap().port(), port);
     }
 }

--- a/src-tauri/src/platform/local_api/mod.rs
+++ b/src-tauri/src/platform/local_api/mod.rs
@@ -1,0 +1,286 @@
+use crate::domain::settings::LocalApiSettings;
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Mutex;
+use tauri::{AppHandle, Runtime};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::broadcast;
+use tokio::time::{timeout, Duration};
+use tokio_tungstenite::{
+    accept_async,
+    tungstenite::{Error as WsError, Message},
+};
+
+const LOCAL_API_AUTH_TIMEOUT_SECS: u64 = 5;
+const LOCAL_API_BROADCAST_CAPACITY: usize = 256;
+pub const LOCAL_API_SETTINGS_CHANGED_EVENT: &str = "app-settings-changed";
+pub const LOCAL_API_ACTIVE_WINDOW_EVENT: &str = "active-window-changed";
+pub const LOCAL_API_TRACKING_DATA_EVENT: &str = "tracking-data-changed";
+
+pub type LocalApiStringFuture = Pin<Box<dyn Future<Output = Option<String>> + Send>>;
+
+pub struct LocalApiRuntimeDeps<R: Runtime> {
+    pub load_token: fn(AppHandle<R>) -> LocalApiStringFuture,
+    pub load_snapshot: fn(AppHandle<R>) -> LocalApiStringFuture,
+}
+
+impl<R: Runtime> Clone for LocalApiRuntimeDeps<R> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<R: Runtime> Copy for LocalApiRuntimeDeps<R> {}
+
+#[derive(Debug)]
+pub struct LocalApiRuntimeState {
+    inner: Mutex<LocalApiRuntimeInner>,
+    event_tx: broadcast::Sender<String>,
+}
+
+#[derive(Debug, Default)]
+struct LocalApiRuntimeInner {
+    settings: LocalApiSettings,
+    server_task: Option<tauri::async_runtime::JoinHandle<()>>,
+}
+
+impl Default for LocalApiRuntimeState {
+    fn default() -> Self {
+        let (event_tx, _) = broadcast::channel(LOCAL_API_BROADCAST_CAPACITY);
+        Self {
+            inner: Mutex::new(LocalApiRuntimeInner::default()),
+            event_tx,
+        }
+    }
+}
+
+impl LocalApiRuntimeState {
+    pub fn update<R: Runtime + 'static>(
+        &self,
+        app: AppHandle<R>,
+        settings: LocalApiSettings,
+        deps: LocalApiRuntimeDeps<R>,
+    ) {
+        let mut inner = lock_inner(&self.inner);
+        let previous_settings = inner.settings.clone();
+        let should_restart = previous_settings.enabled != settings.enabled
+            || previous_settings.port != settings.port
+            || (!settings.enabled && inner.server_task.is_some());
+
+        if should_restart {
+            if let Some(task) = inner.server_task.take() {
+                task.abort();
+            }
+            let _ = self.event_tx.send(close_message());
+        }
+
+        if settings.enabled && (should_restart || inner.server_task.is_none()) {
+            inner.server_task = Some(spawn_server(
+                app,
+                self.event_tx.clone(),
+                settings.clone(),
+                deps,
+            ));
+        }
+
+        inner.settings = settings;
+    }
+
+    pub fn broadcast(&self, message: String) {
+        let _ = self.event_tx.send(message);
+    }
+}
+
+fn spawn_server<R: Runtime + 'static>(
+    app: AppHandle<R>,
+    event_tx: broadcast::Sender<String>,
+    settings: LocalApiSettings,
+    deps: LocalApiRuntimeDeps<R>,
+) -> tauri::async_runtime::JoinHandle<()> {
+    tauri::async_runtime::spawn(async move {
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), settings.port);
+        let listener = match TcpListener::bind(address).await {
+            Ok(listener) => listener,
+            Err(error) => {
+                eprintln!("[local-api] failed to bind {address}: {error}");
+                return;
+            }
+        };
+
+        loop {
+            let (stream, remote_addr) = match listener.accept().await {
+                Ok(next) => next,
+                Err(error) => {
+                    eprintln!("[local-api] accept failed: {error}");
+                    continue;
+                }
+            };
+            let client_app = app.clone();
+            let client_event_tx = event_tx.clone();
+            let token = (deps.load_token)(app.clone())
+                .await
+                .unwrap_or_else(|| settings.token.clone());
+
+            tauri::async_runtime::spawn(async move {
+                if let Err(error) =
+                    handle_client(client_app, client_event_tx, token, stream, deps).await
+                {
+                    eprintln!("[local-api] client {remote_addr} closed: {error}");
+                }
+            });
+        }
+    })
+}
+
+async fn handle_client<R: Runtime>(
+    app: AppHandle<R>,
+    event_tx: broadcast::Sender<String>,
+    token: String,
+    stream: TcpStream,
+    deps: LocalApiRuntimeDeps<R>,
+) -> Result<(), String> {
+    let ws_stream = accept_async(stream)
+        .await
+        .map_err(|error| format!("websocket handshake failed: {error}"))?;
+    let (mut sink, mut stream) = ws_stream.split();
+
+    if !authenticate_client(&mut sink, &mut stream, &token).await? {
+        return Ok(());
+    }
+
+    send_text(&mut sink, auth_ok_message()).await?;
+    if let Some(snapshot) = (deps.load_snapshot)(app).await {
+        send_text(&mut sink, snapshot).await?;
+    }
+
+    let mut rx = event_tx.subscribe();
+    loop {
+        tokio::select! {
+            received = rx.recv() => {
+                match received {
+                    Ok(message) => {
+                        if message == close_message() {
+                            let _ = sink.close().await;
+                            return Ok(());
+                        }
+                        send_text(&mut sink, message).await?;
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                }
+            }
+            next = stream.next() => {
+                match next {
+                    Some(Ok(message)) if message.is_close() => return Ok(()),
+                    Some(Ok(_)) => {}
+                    Some(Err(error)) => return Err(format!("receive failed: {error}")),
+                    None => return Ok(()),
+                }
+            }
+        }
+    }
+}
+
+async fn authenticate_client<S>(
+    sink: &mut S,
+    stream: &mut futures_util::stream::SplitStream<tokio_tungstenite::WebSocketStream<TcpStream>>,
+    token: &str,
+) -> Result<bool, String>
+where
+    S: futures_util::Sink<Message, Error = WsError> + Unpin,
+{
+    if token.is_empty() {
+        return Ok(true);
+    }
+
+    let auth_message = match timeout(
+        Duration::from_secs(LOCAL_API_AUTH_TIMEOUT_SECS),
+        stream.next(),
+    )
+    .await
+    {
+        Ok(message) => message,
+        Err(_) => {
+            send_text(sink, auth_failed_message()).await?;
+            let _ = sink.close().await;
+            return Ok(false);
+        }
+    };
+
+    let Some(Ok(message)) = auth_message else {
+        send_text(sink, auth_failed_message()).await?;
+        let _ = sink.close().await;
+        return Ok(false);
+    };
+
+    if parse_auth_token(&message).as_deref() == Some(token) {
+        return Ok(true);
+    }
+
+    send_text(sink, auth_failed_message()).await?;
+    let _ = sink.close().await;
+    Ok(false)
+}
+
+async fn send_text<S>(sink: &mut S, text: String) -> Result<(), String>
+where
+    S: futures_util::Sink<Message, Error = WsError> + Unpin,
+{
+    sink.send(Message::Text(text.into()))
+        .await
+        .map_err(|error| format!("send failed: {error}"))
+}
+
+fn parse_auth_token(message: &Message) -> Option<String> {
+    let text = message.to_text().ok()?;
+    let value: Value = serde_json::from_str(text).ok()?;
+    let message_type = value.get("type")?.as_str()?;
+    if message_type != "auth" {
+        return None;
+    }
+    value.get("token")?.as_str().map(str::to_string)
+}
+
+pub fn message_json(message_type: &str, data: Value) -> String {
+    json!({
+        "type": message_type,
+        "data": data,
+    })
+    .to_string()
+}
+
+fn auth_ok_message() -> String {
+    json!({ "type": "auth-ok" }).to_string()
+}
+
+fn auth_failed_message() -> String {
+    json!({ "type": "auth-failed" }).to_string()
+}
+
+fn close_message() -> String {
+    json!({ "type": "service-stopping" }).to_string()
+}
+
+fn lock_inner<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_token_accepts_expected_shape() {
+        let message = Message::Text(r#"{"type":"auth","token":"abc"}"#.into());
+        assert_eq!(parse_auth_token(&message).as_deref(), Some("abc"));
+
+        let wrong = Message::Text(r#"{"type":"hello","token":"abc"}"#.into());
+        assert_eq!(parse_auth_token(&wrong), None);
+    }
+}

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1,1 +1,2 @@
-﻿pub mod windows;
+pub mod local_api;
+pub mod windows;

--- a/src/features/settings/components/Settings.tsx
+++ b/src/features/settings/components/Settings.tsx
@@ -11,6 +11,7 @@ import SettingsAppearancePanel from "./SettingsAppearancePanel";
 import SettingsDataSafetyPanel from "./SettingsDataSafetyPanel";
 import SettingsResidentPanel from "./SettingsResidentPanel";
 import SettingsTrackingPanel from "./SettingsTrackingPanel";
+import SettingsLocalApiPanel from "./SettingsLocalApiPanel";
 import { useSettingsPageState } from "../hooks/useSettingsPageState";
 
 export default function Settings({
@@ -201,6 +202,15 @@ export default function Settings({
             startMinimizedChecked={draftSettings.startMinimized}
             startMinimizedDisabled={!draftSettings.launchAtLogin}
             onStartMinimizedChange={(nextChecked) => handleChange("startMinimized", nextChecked)}
+          />
+
+          <SettingsLocalApiPanel
+            enabled={draftSettings.localApiEnabled}
+            port={draftSettings.localApiPort}
+            token={draftSettings.localApiToken}
+            onEnabledChange={(nextChecked) => handleChange("localApiEnabled", nextChecked)}
+            onPortChange={(nextPort) => handleChange("localApiPort", nextPort)}
+            onTokenChange={(nextToken) => handleChange("localApiToken", nextToken)}
           />
 
           <SettingsDataSafetyPanel

--- a/src/features/settings/components/SettingsLocalApiPanel.tsx
+++ b/src/features/settings/components/SettingsLocalApiPanel.tsx
@@ -2,6 +2,7 @@ import { Cable } from "lucide-react";
 import { useEffect, useState } from "react";
 import QuietSwitch from "../../../shared/components/QuietSwitch";
 import { UI_TEXT } from "../../../shared/copy/uiText.ts";
+import { buildLocalApiEnabledChange } from "../services/localApiTokenService.ts";
 
 type SettingsLocalApiPanelProps = {
   enabled: boolean;
@@ -36,6 +37,14 @@ export default function SettingsLocalApiPanel({
     setPortDraft(String(port));
   }, [port]);
 
+  const handleEnabledChange = (nextChecked: boolean) => {
+    const change = buildLocalApiEnabledChange(nextChecked, token);
+    if (change.token !== null && change.token !== token) {
+      onTokenChange(change.token);
+    }
+    onEnabledChange(change.enabled);
+  };
+
   return (
     <section className="qp-panel p-5 md:p-6">
       <div className="flex items-center gap-2.5 pb-2 border-b border-[var(--qp-border-subtle)]">
@@ -54,7 +63,7 @@ export default function SettingsLocalApiPanel({
             </p>
             <QuietSwitch
               checked={enabled}
-              onChange={onEnabledChange}
+              onChange={handleEnabledChange}
               ariaLabel={UI_TEXT.accessibility.settings.toggleLocalApi}
             />
           </div>
@@ -79,7 +88,7 @@ export default function SettingsLocalApiPanel({
             max={LOCAL_API_PORT_MAX}
             step={1}
             value={portDraft}
-          onChange={(event) => {
+            onChange={(event) => {
               const nextDraft = event.target.value;
               setPortDraft(nextDraft);
               const normalized = normalizePort(nextDraft);

--- a/src/features/settings/components/SettingsLocalApiPanel.tsx
+++ b/src/features/settings/components/SettingsLocalApiPanel.tsx
@@ -69,46 +69,46 @@ export default function SettingsLocalApiPanel({
           </div>
         </div>
 
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-[minmax(0,1fr)_180px]">
-          <div>
-            <label
-              htmlFor="settings-local-api-port"
-              className="text-[11px] font-semibold text-[var(--qp-text-tertiary)] uppercase tracking-[0.06em]"
-            >
-              {UI_TEXT.settings.localApiPortLabel}
-            </label>
-            <p className="mt-2 text-sm text-[var(--qp-text-secondary)] leading-relaxed">
+        <div>
+          <label
+            htmlFor="settings-local-api-port"
+            className="text-[11px] font-semibold text-[var(--qp-text-tertiary)] uppercase tracking-[0.06em]"
+          >
+            {UI_TEXT.settings.localApiPortLabel}
+          </label>
+          <div className="mt-2 flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4">
+            <p className="text-sm text-[var(--qp-text-secondary)] leading-relaxed">
               {UI_TEXT.settings.localApiPortHint}
             </p>
+            <input
+              id="settings-local-api-port"
+              type="number"
+              min={LOCAL_API_PORT_MIN}
+              max={LOCAL_API_PORT_MAX}
+              step={1}
+              value={portDraft}
+              onChange={(event) => {
+                const nextDraft = event.target.value;
+                setPortDraft(nextDraft);
+                const normalized = normalizePort(nextDraft);
+                if (normalized) {
+                  onPortChange(Number(normalized));
+                }
+              }}
+              onBlur={() => {
+                const normalized = normalizePort(portDraft);
+                if (normalized) {
+                  setPortDraft(normalized);
+                  onPortChange(Number(normalized));
+                } else {
+                  setPortDraft(String(port));
+                }
+              }}
+              className="h-9 w-full rounded-[8px] border border-[var(--qp-border-subtle)] bg-[var(--qp-bg-panel)] px-3 text-sm font-medium tabular-nums text-[var(--qp-text-primary)] outline-none focus:border-[var(--qp-accent-default)] disabled:cursor-not-allowed disabled:opacity-50 md:w-[180px]"
+              disabled={!enabled}
+              inputMode="numeric"
+            />
           </div>
-          <input
-            id="settings-local-api-port"
-            type="number"
-            min={LOCAL_API_PORT_MIN}
-            max={LOCAL_API_PORT_MAX}
-            step={1}
-            value={portDraft}
-            onChange={(event) => {
-              const nextDraft = event.target.value;
-              setPortDraft(nextDraft);
-              const normalized = normalizePort(nextDraft);
-              if (normalized) {
-                onPortChange(Number(normalized));
-              }
-            }}
-            onBlur={() => {
-              const normalized = normalizePort(portDraft);
-              if (normalized) {
-                setPortDraft(normalized);
-                onPortChange(Number(normalized));
-              } else {
-                setPortDraft(String(port));
-              }
-            }}
-            className="h-9 rounded-[8px] border border-[var(--qp-border-subtle)] bg-[var(--qp-bg-panel)] px-3 text-sm font-medium tabular-nums text-[var(--qp-text-primary)] outline-none focus:border-[var(--qp-accent-default)] disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={!enabled}
-            inputMode="numeric"
-          />
         </div>
 
         <div>

--- a/src/features/settings/components/SettingsLocalApiPanel.tsx
+++ b/src/features/settings/components/SettingsLocalApiPanel.tsx
@@ -1,0 +1,128 @@
+import { Cable } from "lucide-react";
+import { useEffect, useState } from "react";
+import QuietSwitch from "../../../shared/components/QuietSwitch";
+import { UI_TEXT } from "../../../shared/copy/uiText.ts";
+
+type SettingsLocalApiPanelProps = {
+  enabled: boolean;
+  port: number;
+  token: string;
+  onEnabledChange: (nextChecked: boolean) => void;
+  onPortChange: (nextPort: number) => void;
+  onTokenChange: (nextToken: string) => void;
+};
+
+const LOCAL_API_PORT_MIN = 1024;
+const LOCAL_API_PORT_MAX = 65535;
+
+function normalizePort(value: string) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) return "";
+  if (parsed < LOCAL_API_PORT_MIN || parsed > LOCAL_API_PORT_MAX) return "";
+  return String(parsed);
+}
+
+export default function SettingsLocalApiPanel({
+  enabled,
+  port,
+  token,
+  onEnabledChange,
+  onPortChange,
+  onTokenChange,
+}: SettingsLocalApiPanelProps) {
+  const [portDraft, setPortDraft] = useState(String(port));
+
+  useEffect(() => {
+    setPortDraft(String(port));
+  }, [port]);
+
+  return (
+    <section className="qp-panel p-5 md:p-6">
+      <div className="flex items-center gap-2.5 pb-2 border-b border-[var(--qp-border-subtle)]">
+        <Cable size={16} className="text-[var(--qp-accent-default)]" />
+        <h2 className="text-sm font-semibold text-[var(--qp-text-primary)]">{UI_TEXT.settings.localApiTitle}</h2>
+      </div>
+
+      <div className="mt-5 space-y-5">
+        <div>
+          <label className="text-[11px] font-semibold text-[var(--qp-text-tertiary)] uppercase tracking-[0.06em]">
+            {UI_TEXT.settings.localApiEnabledLabel}
+          </label>
+          <div className="mt-2 flex items-start justify-between gap-4">
+            <p className="text-sm text-[var(--qp-text-secondary)] leading-relaxed">
+              {UI_TEXT.settings.localApiEnabledHint}
+            </p>
+            <QuietSwitch
+              checked={enabled}
+              onChange={onEnabledChange}
+              ariaLabel={UI_TEXT.accessibility.settings.toggleLocalApi}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-[minmax(0,1fr)_180px]">
+          <div>
+            <label
+              htmlFor="settings-local-api-port"
+              className="text-[11px] font-semibold text-[var(--qp-text-tertiary)] uppercase tracking-[0.06em]"
+            >
+              {UI_TEXT.settings.localApiPortLabel}
+            </label>
+            <p className="mt-2 text-sm text-[var(--qp-text-secondary)] leading-relaxed">
+              {UI_TEXT.settings.localApiPortHint}
+            </p>
+          </div>
+          <input
+            id="settings-local-api-port"
+            type="number"
+            min={LOCAL_API_PORT_MIN}
+            max={LOCAL_API_PORT_MAX}
+            step={1}
+            value={portDraft}
+          onChange={(event) => {
+              const nextDraft = event.target.value;
+              setPortDraft(nextDraft);
+              const normalized = normalizePort(nextDraft);
+              if (normalized) {
+                onPortChange(Number(normalized));
+              }
+            }}
+            onBlur={() => {
+              const normalized = normalizePort(portDraft);
+              if (normalized) {
+                setPortDraft(normalized);
+                onPortChange(Number(normalized));
+              } else {
+                setPortDraft(String(port));
+              }
+            }}
+            className="h-9 rounded-[8px] border border-[var(--qp-border-subtle)] bg-[var(--qp-bg-panel)] px-3 text-sm font-medium tabular-nums text-[var(--qp-text-primary)] outline-none focus:border-[var(--qp-accent-default)] disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!enabled}
+            inputMode="numeric"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="settings-local-api-token"
+            className="text-[11px] font-semibold text-[var(--qp-text-tertiary)] uppercase tracking-[0.06em]"
+          >
+            {UI_TEXT.settings.localApiTokenLabel}
+          </label>
+          <p className="mt-2 text-sm text-[var(--qp-text-secondary)] leading-relaxed">
+            {UI_TEXT.settings.localApiTokenHint}
+          </p>
+          <input
+            id="settings-local-api-token"
+            type="password"
+            value={token}
+            onChange={(event) => onTokenChange(event.target.value)}
+            className="mt-3 h-9 w-full rounded-[8px] border border-[var(--qp-border-subtle)] bg-[var(--qp-bg-panel)] px-3 text-sm font-medium text-[var(--qp-text-primary)] outline-none focus:border-[var(--qp-accent-default)] disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!enabled}
+            autoComplete="off"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/settings/services/localApiTokenService.ts
+++ b/src/features/settings/services/localApiTokenService.ts
@@ -1,0 +1,35 @@
+const LOCAL_API_TOKEN_BYTES = 24;
+
+type FillRandomValues = (bytes: Uint8Array) => Uint8Array;
+
+function fillSecureRandomValues(bytes: Uint8Array) {
+  if (!globalThis.crypto?.getRandomValues) {
+    throw new Error("secure random values are unavailable");
+  }
+  return globalThis.crypto.getRandomValues(bytes);
+}
+
+export function createLocalApiToken(fillRandomValues: FillRandomValues = fillSecureRandomValues) {
+  const bytes = new Uint8Array(LOCAL_API_TOKEN_BYTES);
+  fillRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function buildLocalApiEnabledChange(
+  nextChecked: boolean,
+  currentToken: string,
+  createToken: () => string = createLocalApiToken,
+) {
+  if (!nextChecked) {
+    return {
+      enabled: false,
+      token: null,
+    };
+  }
+
+  const token = currentToken.trim() || createToken();
+  return {
+    enabled: token.length > 0,
+    token,
+  };
+}

--- a/src/platform/persistence/appSettingsStore.ts
+++ b/src/platform/persistence/appSettingsStore.ts
@@ -106,6 +106,10 @@ function normalizeIntegerRangeValue(
   return parsed;
 }
 
+function normalizeLocalApiToken(value: string | undefined) {
+  return value?.trim() ?? DEFAULT_SETTINGS.localApiToken;
+}
+
 function parseBooleanSetting(value: string | undefined, fallback: boolean) {
   if (value === undefined) return fallback;
   const normalized = value.trim().toLowerCase();
@@ -207,6 +211,8 @@ function serializeSettingValue(value: PersistedSettingValue) {
 }
 
 export function normalizeSettingsRecord(record: Record<string, string | undefined>): AppSettings {
+  const localApiToken = normalizeLocalApiToken(record.local_api_token);
+
   return {
     idleTimeoutSecs: normalizeRangeStepValue(
       record.idle_timeout_secs,
@@ -248,13 +254,14 @@ export function normalizeSettingsRecord(record: Record<string, string | undefine
       record.onboarding_completed,
       DEFAULT_SETTINGS.onboardingCompleted,
     ),
-    localApiEnabled: parseBooleanSetting(record.local_api_enabled, DEFAULT_SETTINGS.localApiEnabled),
+    localApiEnabled: parseBooleanSetting(record.local_api_enabled, DEFAULT_SETTINGS.localApiEnabled)
+      && localApiToken.length > 0,
     localApiPort: normalizeIntegerRangeValue(
       record.local_api_port,
       DEFAULT_SETTINGS.localApiPort,
       LOCAL_API_PORT_RANGE,
     ),
-    localApiToken: record.local_api_token ?? DEFAULT_SETTINGS.localApiToken,
+    localApiToken,
   };
 }
 

--- a/src/platform/persistence/appSettingsStore.ts
+++ b/src/platform/persistence/appSettingsStore.ts
@@ -44,7 +44,10 @@ type RawAppSettingsKey =
   | "color_scheme_dark"
   | "launch_at_login"
   | "start_minimized"
-  | "onboarding_completed";
+  | "onboarding_completed"
+  | "local_api_enabled"
+  | "local_api_port"
+  | "local_api_token";
 
 const APP_SETTINGS_RAW_KEYS: Record<keyof AppSettings, RawAppSettingsKey> = {
   idleTimeoutSecs: "idle_timeout_secs",
@@ -62,12 +65,16 @@ const APP_SETTINGS_RAW_KEYS: Record<keyof AppSettings, RawAppSettingsKey> = {
   launchAtLogin: "launch_at_login",
   startMinimized: "start_minimized",
   onboardingCompleted: "onboarding_completed",
+  localApiEnabled: "local_api_enabled",
+  localApiPort: "local_api_port",
+  localApiToken: "local_api_token",
 };
 
 const IDLE_TIMEOUT_SECONDS_RANGE = { min: 300, max: 1800, step: 60 } as const;
 const TIMELINE_MERGE_GAP_SECONDS_RANGE = { min: 60, max: 300, step: 60 } as const;
 const REFRESH_INTERVAL_OPTIONS = [1, 3];
 const MIN_SESSION_SECONDS_RANGE = { min: 60, max: 600, step: 60 } as const;
+const LOCAL_API_PORT_RANGE = { min: 1024, max: 65535 } as const;
 function parseNumberSetting(value: string | undefined, fallback: number) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : fallback;
@@ -86,6 +93,17 @@ function normalizeRangeStepValue(
   const parsed = parseNumberSetting(value, fallback);
   const clamped = Math.min(range.max, Math.max(range.min, parsed));
   return Math.round(clamped / range.step) * range.step;
+}
+
+function normalizeIntegerRangeValue(
+  value: string | undefined,
+  fallback: number,
+  range: { min: number; max: number },
+) {
+  const parsed = parseNumberSetting(value, fallback);
+  if (!Number.isInteger(parsed)) return fallback;
+  if (parsed < range.min || parsed > range.max) return fallback;
+  return parsed;
 }
 
 function parseBooleanSetting(value: string | undefined, fallback: boolean) {
@@ -230,6 +248,13 @@ export function normalizeSettingsRecord(record: Record<string, string | undefine
       record.onboarding_completed,
       DEFAULT_SETTINGS.onboardingCompleted,
     ),
+    localApiEnabled: parseBooleanSetting(record.local_api_enabled, DEFAULT_SETTINGS.localApiEnabled),
+    localApiPort: normalizeIntegerRangeValue(
+      record.local_api_port,
+      DEFAULT_SETTINGS.localApiPort,
+      LOCAL_API_PORT_RANGE,
+    ),
+    localApiToken: record.local_api_token ?? DEFAULT_SETTINGS.localApiToken,
   };
 }
 

--- a/src/shared/copy/uiText.ts
+++ b/src/shared/copy/uiText.ts
@@ -274,11 +274,11 @@ const ZH_CN_UI_TEXT = {
     startMinimizedHint: "仅对自启动生效：启动时按当前最小化行为收起。",
     localApiTitle: "本机接口",
     localApiEnabledLabel: "WebSocket 服务",
-    localApiEnabledHint: "只监听 127.0.0.1，供本机脚本或面板读取当前追踪状态。",
+    localApiEnabledHint: "仅本机监听，供第三方脚本或面板读取当前追踪状态。",
     localApiPortLabel: "端口",
-    localApiPortHint: "本机访问地址为 ws://127.0.0.1:端口。",
+    localApiPortHint: "本机访问地址为 ws://127.0.0.1:[端口]。",
     localApiTokenLabel: "Token",
-    localApiTokenHint: "非空时，客户端连接后需先发送 auth 消息；留空则跳过认证。",
+    localApiTokenHint: "开启时会自动生成 Token；客户端连接后需先发送 auth 消息。",
     appearanceTitle: "外观",
     themeModeOptions: {
       light: "浅色",
@@ -761,7 +761,7 @@ const EN_US_UI_TEXT: UiText = {
     localApiPortLabel: "Port",
     localApiPortHint: "Local address: ws://127.0.0.1:port.",
     localApiTokenLabel: "Token",
-    localApiTokenHint: "When set, clients must send an auth message after connecting. Leave empty to skip auth.",
+    localApiTokenHint: "A token is generated when enabled. Clients must send an auth message after connecting.",
     appearanceTitle: "Appearance",
     themeModeOptions: {
       light: "Light",

--- a/src/shared/copy/uiText.ts
+++ b/src/shared/copy/uiText.ts
@@ -88,6 +88,7 @@ const ZH_CN_UI_TEXT = {
       toggleCloseToTray: "切换关闭到托盘",
       toggleLaunchAtLogin: "切换开机自启动",
       toggleStartMinimized: "切换启动时最小化",
+      toggleLocalApi: "切换本机接口",
       colorScheme: "配色方案",
     },
     color: {
@@ -271,6 +272,13 @@ const ZH_CN_UI_TEXT = {
     launchAtLoginHint: "开启后，系统登录时自动启动应用。",
     startMinimizedLabel: "启动时最小化",
     startMinimizedHint: "仅对自启动生效：启动时按当前最小化行为收起。",
+    localApiTitle: "本机接口",
+    localApiEnabledLabel: "WebSocket 服务",
+    localApiEnabledHint: "只监听 127.0.0.1，供本机脚本或面板读取当前追踪状态。",
+    localApiPortLabel: "端口",
+    localApiPortHint: "本机访问地址为 ws://127.0.0.1:端口。",
+    localApiTokenLabel: "Token",
+    localApiTokenHint: "非空时，客户端连接后需先发送 auth 消息；留空则跳过认证。",
     appearanceTitle: "外观",
     themeModeOptions: {
       light: "浅色",
@@ -562,6 +570,7 @@ const EN_US_UI_TEXT: UiText = {
       toggleCloseToTray: "Toggle close to tray",
       toggleLaunchAtLogin: "Toggle launch at login",
       toggleStartMinimized: "Toggle start minimized",
+      toggleLocalApi: "Toggle local API",
       colorScheme: "Color scheme",
     },
     color: {
@@ -746,6 +755,13 @@ const EN_US_UI_TEXT: UiText = {
     launchAtLoginHint: "Start the app automatically when Windows signs in.",
     startMinimizedLabel: "Start minimized",
     startMinimizedHint: "Only applies to launch at login. Starts with the current minimize behavior.",
+    localApiTitle: "Local API",
+    localApiEnabledLabel: "WebSocket service",
+    localApiEnabledHint: "Listens on 127.0.0.1 only for local scripts or dashboards to read tracking state.",
+    localApiPortLabel: "Port",
+    localApiPortHint: "Local address: ws://127.0.0.1:port.",
+    localApiTokenLabel: "Token",
+    localApiTokenHint: "When set, clients must send an auth message after connecting. Leave empty to skip auth.",
     appearanceTitle: "Appearance",
     themeModeOptions: {
       light: "Light",

--- a/src/shared/copy/uiText.ts
+++ b/src/shared/copy/uiText.ts
@@ -278,7 +278,7 @@ const ZH_CN_UI_TEXT = {
     localApiPortLabel: "端口",
     localApiPortHint: "本机访问地址为 ws://127.0.0.1:[端口]。",
     localApiTokenLabel: "Token",
-    localApiTokenHint: "开启时会自动生成 Token；客户端连接后需先发送 auth 消息。",
+    localApiTokenHint: "开启时会自动生成 Token 作为鉴权信息",
     appearanceTitle: "外观",
     themeModeOptions: {
       light: "浅色",

--- a/src/shared/settings/appSettings.ts
+++ b/src/shared/settings/appSettings.ts
@@ -51,6 +51,9 @@ export interface AppSettings {
   launchAtLogin: boolean;
   startMinimized: boolean;
   onboardingCompleted: boolean;
+  localApiEnabled: boolean;
+  localApiPort: number;
+  localApiToken: string;
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {

--- a/src/shared/settings/releaseDefaultProfile.ts
+++ b/src/shared/settings/releaseDefaultProfile.ts
@@ -57,6 +57,9 @@ export interface ReleaseDefaultSettingsProfile {
   launchAtLogin: boolean;
   startMinimized: boolean;
   onboardingCompleted: boolean;
+  localApiEnabled: boolean;
+  localApiPort: number;
+  localApiToken: string;
 }
 
 export const RELEASE_DEFAULT_SETTINGS: ReleaseDefaultSettingsProfile = {
@@ -75,4 +78,7 @@ export const RELEASE_DEFAULT_SETTINGS: ReleaseDefaultSettingsProfile = {
   launchAtLogin: true,
   startMinimized: true,
   onboardingCompleted: true,
+  localApiEnabled: false,
+  localApiPort: 17321,
+  localApiToken: "",
 };

--- a/tests/settingsPageState.test.ts
+++ b/tests/settingsPageState.test.ts
@@ -13,6 +13,10 @@ import {
 import {
   normalizeSettingsRecord,
 } from "../src/platform/persistence/appSettingsStore.ts";
+import {
+  buildLocalApiEnabledChange,
+  createLocalApiToken,
+} from "../src/features/settings/services/localApiTokenService.ts";
 
 interface AppSettings {
   idleTimeoutSecs: number;
@@ -310,6 +314,13 @@ await runTest("normalizeSettingsRecord accepts current minimize behavior values"
   assert.equal(invalidLocalApiSettings.localApiEnabled, false);
   assert.equal(invalidLocalApiSettings.localApiPort, 17321);
 
+  const missingTokenSettings = normalizeSettingsRecord({
+    local_api_enabled: "1",
+    local_api_token: "   ",
+  });
+  assert.equal(missingTokenSettings.localApiEnabled, false);
+  assert.equal(missingTokenSettings.localApiToken, "");
+
   const widgetSettings = normalizeSettingsRecord({
     minimize_behavior: "widget",
     close_behavior: "tray",
@@ -398,6 +409,27 @@ await runTest("normalizeSettingsRecord accepts color schemes and falls back to d
   assert.equal(normalizeSettingsRecord({ color_scheme_light: "marketplace" }).colorSchemeLight, "default");
   assert.equal(normalizeSettingsRecord({ color_scheme: "github" }).colorSchemeLight, "default");
   assert.equal(normalizeSettingsRecord({ color_scheme: "github" }).colorSchemeDark, "default");
+});
+
+await runTest("local API token is generated before enabling", () => {
+  const token = createLocalApiToken((bytes) => {
+    bytes.fill(10);
+    return bytes;
+  });
+  assert.equal(token, "0a".repeat(24));
+
+  assert.deepEqual(buildLocalApiEnabledChange(true, "", () => "generated-token"), {
+    enabled: true,
+    token: "generated-token",
+  });
+  assert.deepEqual(buildLocalApiEnabledChange(true, " existing-token "), {
+    enabled: true,
+    token: "existing-token",
+  });
+  assert.deepEqual(buildLocalApiEnabledChange(false, "existing-token"), {
+    enabled: false,
+    token: null,
+  });
 });
 
 await runTest("runSettingsCleanupFlow executes confirmed cleanup and reloads", async () => {

--- a/tests/settingsPageState.test.ts
+++ b/tests/settingsPageState.test.ts
@@ -86,6 +86,9 @@ interface AppSettings {
   launchAtLogin: boolean;
   startMinimized: boolean;
   onboardingCompleted: boolean;
+  localApiEnabled: boolean;
+  localApiPort: number;
+  localApiToken: string;
 }
 
 type CleanupRange = 180 | 90 | 60 | 30 | 15 | 7;
@@ -106,6 +109,9 @@ const BASE_SETTINGS: AppSettings = {
   launchAtLogin: false,
   startMinimized: false,
   onboardingCompleted: false,
+  localApiEnabled: false,
+  localApiPort: 17321,
+  localApiToken: "",
 };
 
 function buildSettings(overrides: Partial<AppSettings> = {}): AppSettings {
@@ -150,6 +156,9 @@ await runTest("buildSettingsPatch only keeps changed keys", () => {
     language: "en-US",
     colorSchemeLight: "linear",
     colorSchemeDark: "github",
+    localApiEnabled: true,
+    localApiPort: 18080,
+    localApiToken: "secret",
   });
 
   assert.deepEqual(SettingsRuntimeAdapterService.buildSettingsPatch(saved, draft), {
@@ -159,6 +168,9 @@ await runTest("buildSettingsPatch only keeps changed keys", () => {
     language: "en-US",
     colorSchemeLight: "linear",
     colorSchemeDark: "github",
+    localApiEnabled: true,
+    localApiPort: 18080,
+    localApiToken: "secret",
   });
 });
 
@@ -278,6 +290,25 @@ await runTest("normalizeSettingsRecord accepts current minimize behavior values"
   assert.equal(defaultSettings.colorSchemeLight, "default");
   assert.equal(defaultSettings.colorSchemeDark, "default");
   assert.equal(defaultSettings.minSessionSecs, 300);
+  assert.equal(defaultSettings.localApiEnabled, false);
+  assert.equal(defaultSettings.localApiPort, 17321);
+  assert.equal(defaultSettings.localApiToken, "");
+
+  const localApiSettings = normalizeSettingsRecord({
+    local_api_enabled: "1",
+    local_api_port: "18080",
+    local_api_token: "secret",
+  });
+  assert.equal(localApiSettings.localApiEnabled, true);
+  assert.equal(localApiSettings.localApiPort, 18080);
+  assert.equal(localApiSettings.localApiToken, "secret");
+
+  const invalidLocalApiSettings = normalizeSettingsRecord({
+    local_api_enabled: "no",
+    local_api_port: "80",
+  });
+  assert.equal(invalidLocalApiSettings.localApiEnabled, false);
+  assert.equal(invalidLocalApiSettings.localApiPort, 17321);
 
   const widgetSettings = normalizeSettingsRecord({
     minimize_behavior: "widget",


### PR DESCRIPTION
## 变更内容

- 新增可选的本地 WebSocket 服务（ #4 ），**默认为关闭状态**
- WebSocket 仅监听 `127.0.0.1`，端口号可选，默认为 17321
<img width="584" height="226" alt="image" src="https://github.com/user-attachments/assets/7536fe52-5037-4d6d-a983-266f843051c1" />

## WebSocket 行为

连接地址：

- `ws://127.0.0.1:<端口>`

连接后，客户端将先发送鉴权消息：

```json
{
  "type": "auth",
  "token": "<设置页里的 token>"
}
```

## 安全说明

- WebSocket 只绑定本机地址，且必须带 token 鉴权
- 未在 5 秒内完成鉴权，连接会被关闭。

## 测试用例补充

- 已补充设置页状态测试。
- 已补充本地 API token 生成与启用逻辑测试。
- 已补充 WebSocket 鉴权解析和端口占用恢复测试。

Refs #4