### PR TITLE
fix: 修复长时间运行后的内存与句柄泄漏

### DIFF
--- a/src-tauri/src/app/bootstrap.rs
+++ b/src-tauri/src/app/bootstrap.rs
@@ -5,7 +5,12 @@ use crate::app::{
     state::{AppExitState, DesktopBehaviorState, WidgetWindowLifecycleState},
     tray,
 };
-use crate::engine::{tracking::watchdog::RuntimeHealthState, updater::UpdaterRuntimeState};
+use crate::engine::{
+    tracking::{
+        runtime_snapshot::TrackingRuntimeSnapshotState, watchdog::RuntimeHealthState,
+    },
+    updater::UpdaterRuntimeState,
+};
 use crate::{commands, data};
 
 pub struct BootstrapInput {
@@ -43,6 +48,7 @@ fn register_managed_state_and_plugins(
         .manage(DesktopBehaviorState::default())
         .manage(AppExitState::default())
         .manage(WidgetWindowLifecycleState::default())
+        .manage(TrackingRuntimeSnapshotState::default())
         .manage(crate::platform::local_api::LocalApiRuntimeState::default())
         .manage(UpdaterRuntimeState::new(app_version.to_string()))
         .plugin(

--- a/src-tauri/src/app/local_api.rs
+++ b/src-tauri/src/app/local_api.rs
@@ -1,9 +1,10 @@
 use crate::data::repositories::app_settings;
 use crate::data::sqlite_pool::wait_for_sqlite_pool;
-use crate::data::tracking_runtime::TrackingRuntimeDataStore;
 use crate::domain::settings::LocalApiSettings;
 use crate::domain::tracking::TrackingStatusSnapshot;
-use crate::engine::tracking::runtime::load_current_tracking_snapshot;
+use crate::engine::tracking::runtime_snapshot::{
+    TrackingRuntimeProbeStatus, TrackingRuntimeSnapshotState,
+};
 use crate::platform::local_api::{
     self, LocalApiRuntimeDeps, LocalApiRuntimeState, LOCAL_API_ACTIVE_WINDOW_EVENT,
     LOCAL_API_SETTINGS_CHANGED_EVENT, LOCAL_API_TRACKING_DATA_EVENT,
@@ -19,6 +20,9 @@ use tauri::{AppHandle, Listener, Manager, Runtime};
 struct LocalApiTrackingSnapshot {
     window: WindowInfo,
     status: TrackingStatusSnapshot,
+    sampled_at_ms: i64,
+    probe_status: TrackingRuntimeProbeStatus,
+    degraded_reason: Option<String>,
 }
 
 pub fn start<R: Runtime + 'static>(app: AppHandle<R>) {
@@ -116,12 +120,15 @@ fn load_current_token_boxed<R: Runtime + 'static>(
 }
 
 async fn load_snapshot_message<R: Runtime>(app: AppHandle<R>) -> Option<String> {
-    let pool = wait_for_sqlite_pool(&app).await.ok()?;
-    let data = TrackingRuntimeDataStore::new(pool);
-    let snapshot = load_current_tracking_snapshot(&data).await.ok()?;
+    let snapshot = app
+        .try_state::<TrackingRuntimeSnapshotState>()?
+        .snapshot()?;
     let payload = LocalApiTrackingSnapshot {
         window: snapshot.window,
         status: snapshot.status,
+        sampled_at_ms: snapshot.sampled_at_ms,
+        probe_status: snapshot.probe_status,
+        degraded_reason: snapshot.degraded_reason,
     };
     Some(local_api::message_json(
         "snapshot",

--- a/src-tauri/src/commands/tracking.rs
+++ b/src-tauri/src/commands/tracking.rs
@@ -1,30 +1,43 @@
-use crate::data::sqlite_pool::wait_for_sqlite_pool;
-use crate::data::tracking_runtime::TrackingRuntimeDataStore;
 use crate::domain::tracking::TrackingStatusSnapshot;
+use crate::engine::tracking::runtime_snapshot::{
+    TrackingRuntimeProbeStatus, TrackingRuntimeSnapshotState,
+};
+use crate::platform::windows::foreground::WindowInfo;
 use serde::Serialize;
+use tauri::Manager;
 
 #[derive(Clone, Debug, Serialize)]
 pub struct CurrentTrackingSnapshot {
-    pub window: crate::platform::windows::foreground::WindowInfo,
+    pub window: WindowInfo,
     pub status: TrackingStatusSnapshot,
+    pub sampled_at_ms: i64,
+    pub probe_status: TrackingRuntimeProbeStatus,
+    pub degraded_reason: Option<String>,
 }
 
 #[tauri::command]
-pub fn get_current_active_window() -> crate::platform::windows::foreground::WindowInfo {
-    crate::platform::windows::foreground::get_current_active_window()
+pub fn get_current_active_window(app: tauri::AppHandle) -> Result<WindowInfo, String> {
+    app.state::<TrackingRuntimeSnapshotState>()
+        .snapshot()
+        .map(|snapshot| snapshot.window)
+        .ok_or_else(|| "tracking runtime snapshot is not ready".to_string())
 }
 
 #[tauri::command]
-pub async fn get_current_tracking_snapshot(
+pub fn get_current_tracking_snapshot(
     app: tauri::AppHandle,
 ) -> Result<CurrentTrackingSnapshot, String> {
-    let pool = wait_for_sqlite_pool(&app).await?;
-    let data = TrackingRuntimeDataStore::new(pool);
-    let snapshot = crate::engine::tracking::runtime::load_current_tracking_snapshot(&data).await?;
+    let snapshot = app
+        .state::<TrackingRuntimeSnapshotState>()
+        .snapshot()
+        .ok_or_else(|| "tracking runtime snapshot is not ready".to_string())?;
 
     Ok(CurrentTrackingSnapshot {
         window: snapshot.window,
         status: snapshot.status,
+        sampled_at_ms: snapshot.sampled_at_ms,
+        probe_status: snapshot.probe_status,
+        degraded_reason: snapshot.degraded_reason,
     })
 }
 

--- a/src-tauri/src/engine/tracking/metadata.rs
+++ b/src-tauri/src/engine/tracking/metadata.rs
@@ -1,10 +1,11 @@
 use crate::data::tracking_runtime::{TrackingRuntimeDataError, TrackingRuntimeDataStore};
 use crate::platform::windows::icon as icon_extractor;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
+use tokio::sync::Semaphore;
 use windows::core::PCWSTR;
 use windows::Win32::Storage::FileSystem::{
     GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW,
@@ -12,6 +13,7 @@ use windows::Win32::Storage::FileSystem::{
 
 const VERSION_INFO_NAME_KEYS: [&str; 3] = ["FileDescription", "ProductName", "CompanyName"];
 const ICON_NEGATIVE_CACHE_TTL_MS: i64 = 60 * 60 * 1000;
+const ICON_CACHE_CONCURRENCY_LIMIT: usize = 2;
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -43,6 +45,14 @@ pub async fn ensure_icon_cache(
         return Ok(());
     }
 
+    let Some(_in_flight) = IconCacheInFlightGuard::try_start(exe_name) else {
+        return Ok(());
+    };
+
+    let Ok(_permit) = icon_cache_semaphore().clone().try_acquire_owned() else {
+        return Ok(());
+    };
+
     if data.is_icon_cached(exe_name).await? {
         return Ok(());
     }
@@ -70,6 +80,45 @@ pub async fn ensure_icon_cache(
     data.upsert_icon(exe_name, &base64_icon, now_ms()).await?;
 
     Ok(())
+}
+
+struct IconCacheInFlightGuard {
+    key: String,
+}
+
+impl IconCacheInFlightGuard {
+    fn try_start(exe_name: &str) -> Option<Self> {
+        let key = exe_name.trim().to_ascii_lowercase();
+        if key.is_empty() {
+            return None;
+        }
+
+        let mut in_flight = icon_cache_in_flight().lock().ok()?;
+        if !in_flight.insert(key.clone()) {
+            return None;
+        }
+
+        Some(Self { key })
+    }
+}
+
+impl Drop for IconCacheInFlightGuard {
+    fn drop(&mut self) {
+        if let Ok(mut in_flight) = icon_cache_in_flight().lock() {
+            in_flight.remove(&self.key);
+        }
+    }
+}
+
+fn icon_cache_in_flight() -> &'static Mutex<HashSet<String>> {
+    static ICON_CACHE_IN_FLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    ICON_CACHE_IN_FLIGHT.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn icon_cache_semaphore() -> &'static Arc<Semaphore> {
+    static ICON_CACHE_SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    ICON_CACHE_SEMAPHORE
+        .get_or_init(|| Arc::new(Semaphore::new(ICON_CACHE_CONCURRENCY_LIMIT)))
 }
 
 fn should_skip_window_icon_fallback(exe_name: &str, window_class: &str) -> bool {

--- a/src-tauri/src/engine/tracking/mod.rs
+++ b/src-tauri/src/engine/tracking/mod.rs
@@ -2,6 +2,7 @@ pub mod active_session;
 pub mod continuity;
 pub mod metadata;
 pub mod runtime;
+pub mod runtime_snapshot;
 mod session_timeout;
 pub mod startup;
 mod sustained_participation;

--- a/src-tauri/src/engine/tracking/runtime.rs
+++ b/src-tauri/src/engine/tracking/runtime.rs
@@ -5,6 +5,7 @@ use super::session_timeout::{
     should_suspend_active_tracking,
 };
 use super::sustained_participation::SustainedParticipationRuntimeState;
+use super::runtime_snapshot::{TrackingRuntimeSnapshot, TrackingRuntimeSnapshotState};
 use super::{active_session, continuity, startup, transition, watchdog};
 #[cfg(test)]
 use crate::data::repositories::{sessions, tracker_settings};
@@ -17,7 +18,7 @@ use crate::domain::tracking::TRACKING_REASON_TRACKING_PAUSED_SEALED;
 use crate::domain::tracking::{TrackingStatusSnapshot, TRACKING_REASON_STATUS_CHANGED};
 use crate::platform::windows::foreground as tracker;
 use std::sync::Arc;
-use tauri::{AppHandle, Emitter, Runtime};
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 use tokio::time::{sleep, Duration};
 
 #[path = "runtime/loop_state.rs"]
@@ -30,13 +31,13 @@ mod support;
 mod window_polling;
 
 use loop_state::{
-    load_tracking_loop_state, persist_tracker_runtime_timestamps, CurrentTrackingSnapshotData,
-    TrackerTimestampPersistState, TrackingSettingsCache,
+    load_tracking_loop_state, persist_tracker_runtime_timestamps, TrackerTimestampPersistState,
+    TrackingSettingsCache,
 };
 use power_lifecycle::apply_power_lifecycle_event;
 pub use support::emit_tracking_data_changed;
 use support::{log_tracker_error, now_ms};
-use window_polling::poll_active_window_with_timeout;
+use window_polling::{poll_active_window_with_timeout, WindowPollOutcome};
 
 // Owner ledger: run() owns runtime loop orchestration only. Polling,
 // loop-state loading, power lifecycle handling, and event support stay in the
@@ -60,10 +61,20 @@ pub async fn run<R: Runtime>(
     let mut settings_cache = TrackingSettingsCache::default();
 
     loop {
-        let window_info = poll_active_window_with_timeout().await?;
+        let poll_outcome = poll_active_window_with_timeout().await;
+        let window_info = poll_outcome.window.clone();
         let now_ms = now_ms();
-        health_state.note_successful_sample(now_ms);
-        persist_tracker_runtime_timestamps(&data, now_ms, &mut timestamp_persist_state).await;
+        health_state.note_heartbeat(now_ms);
+        if poll_outcome.is_successful_sample() {
+            health_state.note_successful_sample(now_ms);
+        }
+        persist_tracker_runtime_timestamps(
+            &data,
+            now_ms,
+            poll_outcome.is_successful_sample(),
+            &mut timestamp_persist_state,
+        )
+        .await;
         let (tracking_state, next_sustained_participation_state) = load_tracking_loop_state(
             &data,
             &window_info,
@@ -74,22 +85,13 @@ pub async fn run<R: Runtime>(
         .await;
         sustained_participation_state = next_sustained_participation_state;
         let tracked_window = tracking_state.tracked_window;
-        let continuity_group_start_time =
-            continuity::resolve_next_session_continuity_group_start_time(
-                pending_continuity.as_ref(),
-                &tracked_window,
-                now_ms,
-            );
-        let new_pending_continuity = continuity::load_pending_continuity(
-            &data,
-            last_window.as_ref(),
-            last_tracking_status.as_ref(),
+        update_runtime_snapshot_state(
+            &app,
             &tracked_window,
-            tracking_state.continuity_window_secs,
+            &tracking_state.tracking_status,
             now_ms,
-        )
-        .await;
-
+            &poll_outcome,
+        );
         if tracking_state.tracking_paused {
             match seal_active_sessions_for_tracking_pause(&data, now_ms).await {
                 Ok(Some(reason)) => {
@@ -107,6 +109,29 @@ pub async fn run<R: Runtime>(
             sleep(Duration::from_secs(1)).await;
             continue;
         }
+
+        if !poll_outcome.is_successful_sample() {
+            last_window = Some(tracked_window);
+            last_tracking_status = Some(tracking_state.tracking_status);
+            sleep(Duration::from_secs(1)).await;
+            continue;
+        }
+
+        let continuity_group_start_time =
+            continuity::resolve_next_session_continuity_group_start_time(
+                pending_continuity.as_ref(),
+                &tracked_window,
+                now_ms,
+            );
+        let new_pending_continuity = continuity::load_pending_continuity(
+            &data,
+            last_window.as_ref(),
+            last_tracking_status.as_ref(),
+            &tracked_window,
+            tracking_state.continuity_window_secs,
+            now_ms,
+        )
+        .await;
 
         if should_seal_sustained_participation(
             last_window.as_ref(),
@@ -221,6 +246,24 @@ pub async fn run<R: Runtime>(
     }
 }
 
+fn update_runtime_snapshot_state<R: Runtime>(
+    app: &AppHandle<R>,
+    window: &tracker::WindowInfo,
+    status: &TrackingStatusSnapshot,
+    sampled_at_ms: i64,
+    poll_outcome: &WindowPollOutcome,
+) {
+    if let Some(state) = app.try_state::<TrackingRuntimeSnapshotState>() {
+        state.replace(TrackingRuntimeSnapshot {
+            window: window.clone(),
+            status: status.clone(),
+            sampled_at_ms,
+            probe_status: poll_outcome.probe_status,
+            degraded_reason: poll_outcome.degraded_reason.clone(),
+        });
+    }
+}
+
 fn should_emit_tracking_status_changed(
     previous: Option<&TrackingStatusSnapshot>,
     next: &TrackingStatusSnapshot,
@@ -237,26 +280,6 @@ fn should_emit_tracking_status_changed(
         || previous.sustained_participation_signal_source
             != next.sustained_participation_signal_source
         || previous.sustained_participation_reason != next.sustained_participation_reason
-}
-
-pub async fn load_current_tracking_snapshot(
-    data: &TrackingRuntimeDataStore,
-) -> Result<CurrentTrackingSnapshotData, String> {
-    let window_info = poll_active_window_with_timeout().await?;
-    let mut settings_cache = TrackingSettingsCache::default();
-    let (tracking_state, _) = load_tracking_loop_state(
-        data,
-        &window_info,
-        now_ms(),
-        &SustainedParticipationRuntimeState::default(),
-        &mut settings_cache,
-    )
-    .await;
-
-    Ok(CurrentTrackingSnapshotData {
-        window: tracking_state.tracked_window,
-        status: tracking_state.tracking_status,
-    })
 }
 
 pub async fn handle_power_lifecycle_event<R: Runtime>(

--- a/src-tauri/src/engine/tracking/runtime/loop_state.rs
+++ b/src-tauri/src/engine/tracking/runtime/loop_state.rs
@@ -25,14 +25,10 @@ pub(super) struct TrackingLoopState {
     pub tracking_status: TrackingStatusSnapshot,
 }
 
-pub struct CurrentTrackingSnapshotData {
-    pub window: tracker::WindowInfo,
-    pub status: TrackingStatusSnapshot,
-}
-
 #[derive(Debug, Default)]
 pub(super) struct TrackerTimestampPersistState {
-    last_persisted_at_ms: Option<i64>,
+    last_heartbeat_persisted_at_ms: Option<i64>,
+    last_successful_sample_persisted_at_ms: Option<i64>,
 }
 
 #[derive(Debug, Default)]
@@ -57,26 +53,37 @@ struct CachedCaptureWindowTitleSetting {
 pub(super) async fn persist_tracker_runtime_timestamps(
     data: &TrackingRuntimeDataStore,
     now_ms: i64,
+    did_successfully_sample_window: bool,
     state: &mut TrackerTimestampPersistState,
 ) {
-    if state
-        .last_persisted_at_ms
+    if !state
+        .last_heartbeat_persisted_at_ms
         .map(|last| now_ms.saturating_sub(last) < TRACKER_TIMESTAMP_PERSIST_INTERVAL_MS)
         .unwrap_or(false)
     {
-        return;
-    }
-
-    for (setting_key, error_context) in [
-        (TRACKER_LAST_SUCCESSFUL_SAMPLE_KEY, "sample timestamp"),
-        (TRACKER_LAST_HEARTBEAT_KEY, "heartbeat"),
-    ] {
-        if let Err(error) = data.save_tracker_timestamp(setting_key, now_ms).await {
-            log_tracker_error(format!("failed to save tracker {error_context}: {error}"));
+        if let Err(error) = data
+            .save_tracker_timestamp(TRACKER_LAST_HEARTBEAT_KEY, now_ms)
+            .await
+        {
+            log_tracker_error(format!("failed to save tracker heartbeat: {error}"));
         }
+        state.last_heartbeat_persisted_at_ms = Some(now_ms);
     }
 
-    state.last_persisted_at_ms = Some(now_ms);
+    if did_successfully_sample_window
+        && !state
+            .last_successful_sample_persisted_at_ms
+            .map(|last| now_ms.saturating_sub(last) < TRACKER_TIMESTAMP_PERSIST_INTERVAL_MS)
+            .unwrap_or(false)
+    {
+        if let Err(error) = data
+            .save_tracker_timestamp(TRACKER_LAST_SUCCESSFUL_SAMPLE_KEY, now_ms)
+            .await
+        {
+            log_tracker_error(format!("failed to save tracker sample timestamp: {error}"));
+        }
+        state.last_successful_sample_persisted_at_ms = Some(now_ms);
+    }
 }
 
 pub(super) async fn load_tracking_loop_state(

--- a/src-tauri/src/engine/tracking/runtime/window_polling.rs
+++ b/src-tauri/src/engine/tracking/runtime/window_polling.rs
@@ -1,21 +1,285 @@
 use crate::platform::windows::foreground as tracker;
+use super::super::runtime_snapshot::TrackingRuntimeProbeStatus;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex, OnceLock,
+};
 use tokio::task::spawn_blocking;
 use tokio::time::{timeout, Duration};
 
 const WINDOW_POLL_TIMEOUT_SECS: u64 = 3;
 
-pub(super) async fn poll_active_window_with_timeout() -> Result<tracker::WindowInfo, String> {
-    match timeout(
+#[derive(Clone, Debug)]
+pub(super) struct WindowPollOutcome {
+    pub window: tracker::WindowInfo,
+    pub probe_status: TrackingRuntimeProbeStatus,
+    pub degraded_reason: Option<String>,
+}
+
+impl WindowPollOutcome {
+    pub(super) fn is_successful_sample(&self) -> bool {
+        self.probe_status == TrackingRuntimeProbeStatus::Ok
+    }
+}
+
+#[derive(Debug, Default)]
+struct ForegroundProbeState {
+    probe_in_flight: Arc<AtomicBool>,
+    last_successful_window: Mutex<Option<tracker::WindowInfo>>,
+}
+
+struct ForegroundProbeInFlightGuard {
+    probe_in_flight: Arc<AtomicBool>,
+}
+
+pub(super) async fn poll_active_window_with_timeout() -> WindowPollOutcome {
+    poll_active_window_with_state(
+        foreground_probe_state().clone(),
         Duration::from_secs(WINDOW_POLL_TIMEOUT_SECS),
-        spawn_blocking(tracker::get_active_window),
+        tracker::get_active_window,
     )
     .await
-    {
-        Ok(Ok(window_info)) => Ok(window_info),
-        Ok(Err(error)) => Err(format!("active window poll task failed: {error}")),
-        Err(_) => Err(format!(
-            "active window poll timed out after {} seconds",
-            WINDOW_POLL_TIMEOUT_SECS
-        )),
+}
+
+async fn poll_active_window_with_state<F>(
+    state: Arc<ForegroundProbeState>,
+    timeout_duration: Duration,
+    probe: F,
+) -> WindowPollOutcome
+where
+    F: FnOnce() -> tracker::WindowInfo + Send + 'static,
+{
+    if state.probe_in_flight.swap(true, Ordering::AcqRel) {
+        return fallback_outcome(
+            &state,
+            TrackingRuntimeProbeStatus::BackingOffFallback,
+            TrackingRuntimeProbeStatus::BackingOffInactive,
+            "active window probe still in flight",
+        );
+    }
+
+    let probe_in_flight = state.probe_in_flight.clone();
+    let query = spawn_blocking(move || {
+        let _guard = ForegroundProbeInFlightGuard { probe_in_flight };
+        probe()
+    });
+
+    match timeout(timeout_duration, query).await {
+        Ok(Ok(window)) => {
+            remember_successful_window(&state, &window);
+            WindowPollOutcome {
+                window,
+                probe_status: TrackingRuntimeProbeStatus::Ok,
+                degraded_reason: None,
+            }
+        }
+        Ok(Err(error)) => fallback_outcome(
+            &state,
+            TrackingRuntimeProbeStatus::TaskFailedFallback,
+            TrackingRuntimeProbeStatus::TaskFailedInactive,
+            &format!("active window poll task failed: {error}"),
+        ),
+        Err(_) => fallback_outcome(
+            &state,
+            TrackingRuntimeProbeStatus::TimeoutFallback,
+            TrackingRuntimeProbeStatus::TimeoutInactive,
+            &format!(
+                "active window poll timed out after {} seconds",
+                timeout_duration.as_secs()
+            ),
+        ),
+    }
+}
+
+fn fallback_outcome(
+    state: &ForegroundProbeState,
+    fallback_status: TrackingRuntimeProbeStatus,
+    inactive_status: TrackingRuntimeProbeStatus,
+    degraded_reason: &str,
+) -> WindowPollOutcome {
+    let window = load_last_successful_window(state);
+    let has_cached_window = window.is_some();
+    WindowPollOutcome {
+        window: window.unwrap_or_else(inactive_window),
+        probe_status: if has_cached_window {
+            fallback_status
+        } else {
+            inactive_status
+        },
+        degraded_reason: Some(degraded_reason.to_string()),
+    }
+}
+
+fn remember_successful_window(state: &ForegroundProbeState, window: &tracker::WindowInfo) {
+    match state.last_successful_window.lock() {
+        Ok(mut guard) => {
+            *guard = Some(window.clone());
+        }
+        Err(poisoned) => {
+            let mut guard = poisoned.into_inner();
+            *guard = Some(window.clone());
+        }
+    }
+}
+
+fn load_last_successful_window(state: &ForegroundProbeState) -> Option<tracker::WindowInfo> {
+    match state.last_successful_window.lock() {
+        Ok(guard) => guard.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    }
+}
+
+fn inactive_window() -> tracker::WindowInfo {
+    tracker::WindowInfo {
+        hwnd: String::new(),
+        root_owner_hwnd: String::new(),
+        process_id: 0,
+        window_class: String::new(),
+        title: String::new(),
+        exe_name: String::new(),
+        process_path: String::new(),
+        is_afk: false,
+        idle_time_ms: 0,
+    }
+}
+
+fn foreground_probe_state() -> &'static Arc<ForegroundProbeState> {
+    static FOREGROUND_PROBE_STATE: OnceLock<Arc<ForegroundProbeState>> = OnceLock::new();
+    FOREGROUND_PROBE_STATE.get_or_init(|| Arc::new(ForegroundProbeState::default()))
+}
+
+impl Drop for ForegroundProbeInFlightGuard {
+    fn drop(&mut self) {
+        self.probe_in_flight.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+
+    fn make_window(exe_name: &str) -> tracker::WindowInfo {
+        tracker::WindowInfo {
+            hwnd: "0x100".into(),
+            root_owner_hwnd: "0x100".into(),
+            process_id: 123,
+            window_class: "Chrome_WidgetWin_1".into(),
+            title: "Window".into(),
+            exe_name: exe_name.into(),
+            process_path: format!(r"C:\Program Files\{exe_name}"),
+            is_afk: false,
+            idle_time_ms: 0,
+        }
+    }
+
+    #[test]
+    fn poll_returns_cached_window_when_probe_times_out() {
+        tauri::async_runtime::block_on(async {
+            let state = Arc::new(ForegroundProbeState::default());
+            remember_successful_window(&state, &make_window("Code.exe"));
+
+            let outcome = poll_active_window_with_state(
+                state,
+                Duration::from_millis(10),
+                || {
+                    thread::sleep(Duration::from_millis(80));
+                    make_window("Late.exe")
+                },
+            )
+            .await;
+
+            assert_eq!(outcome.window.exe_name, "Code.exe");
+            assert_eq!(outcome.probe_status, TrackingRuntimeProbeStatus::TimeoutFallback);
+            assert!(!outcome.is_successful_sample());
+        });
+    }
+
+    #[test]
+    fn poll_returns_inactive_window_when_probe_times_out_without_cache() {
+        tauri::async_runtime::block_on(async {
+            let state = Arc::new(ForegroundProbeState::default());
+
+            let outcome = poll_active_window_with_state(
+                state,
+                Duration::from_millis(10),
+                || {
+                    thread::sleep(Duration::from_millis(80));
+                    make_window("Late.exe")
+                },
+            )
+            .await;
+
+            assert_eq!(outcome.window.exe_name, "");
+            assert_eq!(outcome.probe_status, TrackingRuntimeProbeStatus::TimeoutInactive);
+            assert!(!outcome.is_successful_sample());
+        });
+    }
+
+    #[test]
+    fn concurrent_polls_reuse_single_in_flight_probe() {
+        tauri::async_runtime::block_on(async {
+            let state = Arc::new(ForegroundProbeState::default());
+            remember_successful_window(&state, &make_window("Code.exe"));
+            let calls = Arc::new(AtomicUsize::new(0));
+            let first_calls = calls.clone();
+            let first_state = state.clone();
+
+            let first = tauri::async_runtime::spawn(async move {
+                poll_active_window_with_state(
+                    first_state,
+                    Duration::from_millis(30),
+                    move || {
+                        first_calls.fetch_add(1, Ordering::SeqCst);
+                        thread::sleep(Duration::from_millis(120));
+                        make_window("Late.exe")
+                    },
+                )
+                .await
+            });
+
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            for _ in 0..10 {
+                let outcome = poll_active_window_with_state(
+                    state.clone(),
+                    Duration::from_millis(30),
+                    || make_window("ShouldNotRun.exe"),
+                )
+                .await;
+                assert_eq!(
+                    outcome.probe_status,
+                    TrackingRuntimeProbeStatus::BackingOffFallback
+                );
+            }
+
+            let first_outcome = first.await.unwrap();
+            assert_eq!(
+                first_outcome.probe_status,
+                TrackingRuntimeProbeStatus::TimeoutFallback
+            );
+            assert_eq!(calls.load(Ordering::SeqCst), 1);
+        });
+    }
+
+    #[test]
+    fn successful_probe_updates_cache() {
+        tauri::async_runtime::block_on(async {
+            let state = Arc::new(ForegroundProbeState::default());
+
+            let outcome = poll_active_window_with_state(
+                state.clone(),
+                Duration::from_millis(50),
+                || make_window("Code.exe"),
+            )
+            .await;
+
+            assert_eq!(outcome.probe_status, TrackingRuntimeProbeStatus::Ok);
+            assert!(outcome.is_successful_sample());
+            assert_eq!(
+                load_last_successful_window(&state).unwrap().exe_name,
+                "Code.exe"
+            );
+        });
     }
 }

--- a/src-tauri/src/engine/tracking/runtime_snapshot.rs
+++ b/src-tauri/src/engine/tracking/runtime_snapshot.rs
@@ -1,0 +1,89 @@
+use crate::domain::tracking::TrackingStatusSnapshot;
+use crate::platform::windows::foreground::WindowInfo;
+use serde::Serialize;
+use std::sync::Mutex;
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum TrackingRuntimeProbeStatus {
+    Ok,
+    TimeoutFallback,
+    TimeoutInactive,
+    BackingOffFallback,
+    BackingOffInactive,
+    TaskFailedFallback,
+    TaskFailedInactive,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct TrackingRuntimeSnapshot {
+    pub window: WindowInfo,
+    pub status: TrackingStatusSnapshot,
+    pub sampled_at_ms: i64,
+    pub probe_status: TrackingRuntimeProbeStatus,
+    pub degraded_reason: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct TrackingRuntimeSnapshotState {
+    inner: Mutex<Option<TrackingRuntimeSnapshot>>,
+}
+
+impl TrackingRuntimeSnapshotState {
+    pub fn replace(&self, snapshot: TrackingRuntimeSnapshot) {
+        match self.inner.lock() {
+            Ok(mut guard) => {
+                *guard = Some(snapshot);
+            }
+            Err(poisoned) => {
+                let mut guard = poisoned.into_inner();
+                *guard = Some(snapshot);
+            }
+        }
+    }
+
+    pub fn snapshot(&self) -> Option<TrackingRuntimeSnapshot> {
+        match self.inner.lock() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_window() -> WindowInfo {
+        WindowInfo {
+            hwnd: "0x100".into(),
+            root_owner_hwnd: "0x100".into(),
+            process_id: 123,
+            window_class: "Chrome_WidgetWin_1".into(),
+            title: "Window".into(),
+            exe_name: "QQ.exe".into(),
+            process_path: r"C:\Program Files\QQ\QQ.exe".into(),
+            is_afk: false,
+            idle_time_ms: 0,
+        }
+    }
+
+    #[test]
+    fn snapshot_state_returns_latest_runtime_snapshot() {
+        let state = TrackingRuntimeSnapshotState::default();
+        let snapshot = TrackingRuntimeSnapshot {
+            window: make_window(),
+            status: TrackingStatusSnapshot::default(),
+            sampled_at_ms: 123,
+            probe_status: TrackingRuntimeProbeStatus::Ok,
+            degraded_reason: None,
+        };
+
+        state.replace(snapshot.clone());
+
+        let loaded = state.snapshot().unwrap();
+        assert_eq!(loaded.sampled_at_ms, 123);
+        assert_eq!(loaded.probe_status, TrackingRuntimeProbeStatus::Ok);
+        assert_eq!(loaded.window.exe_name, snapshot.window.exe_name);
+    }
+}

--- a/src-tauri/src/engine/tracking/watchdog.rs
+++ b/src-tauri/src/engine/tracking/watchdog.rs
@@ -15,11 +15,17 @@ const TRACKER_STALL_SEAL_AFTER_MS: i64 = 8_000;
 
 #[derive(Debug, Default)]
 pub struct RuntimeHealthState {
+    last_heartbeat_ms: AtomicI64,
     last_successful_sample_ms: AtomicI64,
     last_watchdog_seal_sample_ms: AtomicI64,
 }
 
 impl RuntimeHealthState {
+    pub fn note_heartbeat(&self, timestamp_ms: i64) {
+        self.last_heartbeat_ms
+            .store(timestamp_ms, Ordering::Relaxed);
+    }
+
     pub fn note_successful_sample(&self, timestamp_ms: i64) {
         self.last_successful_sample_ms
             .store(timestamp_ms, Ordering::Relaxed);

--- a/src-tauri/src/platform/windows/foreground.rs
+++ b/src-tauri/src/platform/windows/foreground.rs
@@ -321,10 +321,6 @@ unsafe fn get_process_name_from_snapshot(process_id: u32) -> Option<String> {
     exe_name
 }
 
-pub fn get_current_active_window() -> WindowInfo {
-    get_active_window()
-}
-
 #[cfg(test)]
 mod tests {
     use super::{

--- a/src-tauri/src/platform/windows/media.rs
+++ b/src-tauri/src/platform/windows/media.rs
@@ -4,7 +4,10 @@ use crate::domain::tracking::{
     SustainedParticipationSignalSource, SystemMediaPlaybackType,
 };
 use crate::platform::windows::foreground::WindowInfo;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex, OnceLock,
+};
 use tokio::time::{sleep, timeout, Duration};
 use windows::Media::Control::{
     GlobalSystemMediaTransportControlsSession, GlobalSystemMediaTransportControlsSessionManager,
@@ -29,6 +32,11 @@ struct MediaSnapshot {
 #[derive(Debug)]
 struct MediaSignalSourceState {
     snapshot: Mutex<MediaSnapshot>,
+    probe_in_flight: Arc<AtomicBool>,
+}
+
+struct MediaProbeInFlightGuard {
+    probe_in_flight: Arc<AtomicBool>,
 }
 
 pub fn start_signal_source() {
@@ -63,6 +71,7 @@ impl MediaSignalSourceState {
                 freshness_deadline_ms: now_ms().saturating_add(MEDIA_SNAPSHOT_TTL_MS),
                 signal: SustainedParticipationSignalSnapshot::default(),
             }),
+            probe_in_flight: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -75,18 +84,37 @@ impl MediaSignalSourceState {
 
     async fn reconcile_once(&self) {
         let now_ms = now_ms();
+        if self.probe_in_flight.swap(true, Ordering::AcqRel) {
+            self.replace_snapshot(MediaSnapshot {
+                generated_at_ms: now_ms,
+                freshness_deadline_ms: now_ms.saturating_add(MEDIA_SNAPSHOT_TTL_MS),
+                signal: SustainedParticipationSignalSnapshot::default(),
+            });
+            return;
+        }
+
+        let probe_in_flight = self.probe_in_flight.clone();
+        let query = tauri::async_runtime::spawn(async move {
+            let _guard = MediaProbeInFlightGuard { probe_in_flight };
+            query_media_session_signal().await
+        });
+
         let signal = match timeout(
             Duration::from_secs(MEDIA_SESSION_QUERY_TIMEOUT_SECS),
-            query_media_session_signal(),
+            query,
         )
         .await
         {
-            Ok(Ok(Some(signal))) => signal,
-            Ok(Ok(None)) => SustainedParticipationSignalSnapshot::default(),
-            Ok(Err(error)) => {
+            Ok(Ok(Ok(Some(signal)))) => signal,
+            Ok(Ok(Ok(None))) => SustainedParticipationSignalSnapshot::default(),
+            Ok(Ok(Err(error))) => {
                 log_media_probe_error(format!(
                     "failed to reconcile system media sessions: {error}"
                 ));
+                SustainedParticipationSignalSnapshot::default()
+            }
+            Ok(Err(error)) => {
+                log_media_probe_error(format!("system media query task failed: {error}"));
                 SustainedParticipationSignalSnapshot::default()
             }
             Err(_) => {
@@ -97,12 +125,16 @@ impl MediaSignalSourceState {
             }
         };
 
-        if let Ok(mut snapshot) = self.snapshot.lock() {
-            *snapshot = MediaSnapshot {
-                generated_at_ms: now_ms,
-                freshness_deadline_ms: now_ms.saturating_add(MEDIA_SNAPSHOT_TTL_MS),
-                signal,
-            };
+        self.replace_snapshot(MediaSnapshot {
+            generated_at_ms: now_ms,
+            freshness_deadline_ms: now_ms.saturating_add(MEDIA_SNAPSHOT_TTL_MS),
+            signal,
+        });
+    }
+
+    fn replace_snapshot(&self, snapshot: MediaSnapshot) {
+        if let Ok(mut current) = self.snapshot.lock() {
+            *current = snapshot;
         }
     }
 
@@ -136,6 +168,12 @@ impl MediaSignalSourceState {
         }
 
         snapshot.signal
+    }
+}
+
+impl Drop for MediaProbeInFlightGuard {
+    fn drop(&mut self) {
+        self.probe_in_flight.store(false, Ordering::Release);
     }
 }
 

--- a/src/platform/runtime/trackingRawDtos.ts
+++ b/src/platform/runtime/trackingRawDtos.ts
@@ -11,6 +11,7 @@ import type {
   SustainedParticipationStatusReason,
   TrackingDataChangedPayload,
   TrackingStatusSnapshot,
+  TrackingRuntimeProbeStatus,
   TrackingWindowSnapshot,
 } from "../../shared/types/tracking.ts";
 
@@ -65,6 +66,9 @@ export interface RawTrackingStatusSnapshot {
 export interface RawCurrentTrackingSnapshot {
   window: RawTrackingWindowSnapshot;
   status: RawTrackingStatusSnapshot;
+  sampled_at_ms?: number;
+  probe_status?: TrackingRuntimeProbeStatus;
+  degraded_reason?: string | null;
 }
 
 export interface RawTrackingDataChangedPayload {
@@ -232,7 +236,28 @@ export function isRawSustainedParticipationDiagnosticsSnapshot(
 export function isRawCurrentTrackingSnapshot(value: unknown): value is RawCurrentTrackingSnapshot {
   return isRecord(value)
     && isRawTrackingWindowSnapshot(value.window)
-    && isRawTrackingStatusSnapshot(value.status);
+    && isRawTrackingStatusSnapshot(value.status)
+    && (
+      value.sampled_at_ms === undefined
+      || typeof value.sampled_at_ms === "number"
+    )
+    && (
+      value.probe_status === undefined
+      || isEnumValue(value.probe_status, [
+        "ok",
+        "timeout-fallback",
+        "timeout-inactive",
+        "backing-off-fallback",
+        "backing-off-inactive",
+        "task-failed-fallback",
+        "task-failed-inactive",
+      ] as const)
+    )
+    && (
+      value.degraded_reason === undefined
+      || value.degraded_reason === null
+      || typeof value.degraded_reason === "string"
+    );
 }
 
 export function isRawTrackingDataChangedPayload(value: unknown): value is RawTrackingDataChangedPayload {
@@ -317,6 +342,9 @@ export function mapRawCurrentTrackingSnapshot(
   return {
     window: mapRawTrackingWindowSnapshot(raw.window),
     status: mapRawTrackingStatusSnapshot(raw.status),
+    sampledAtMs: raw.sampled_at_ms,
+    probeStatus: raw.probe_status,
+    degradedReason: raw.degraded_reason,
   };
 }
 

--- a/src/shared/types/tracking.ts
+++ b/src/shared/types/tracking.ts
@@ -84,9 +84,21 @@ export interface TrackingStatusSnapshot {
   sustainedParticipationDiagnostics: SustainedParticipationDiagnosticsSnapshot;
 }
 
+export type TrackingRuntimeProbeStatus =
+  | "ok"
+  | "timeout-fallback"
+  | "timeout-inactive"
+  | "backing-off-fallback"
+  | "backing-off-inactive"
+  | "task-failed-fallback"
+  | "task-failed-inactive";
+
 export interface CurrentTrackingSnapshot {
   window: TrackingWindowSnapshot;
   status: TrackingStatusSnapshot;
+  sampledAtMs?: number;
+  probeStatus?: TrackingRuntimeProbeStatus;
+  degradedReason?: string | null;
 }
 
 export interface TrackingDataChangedPayload {
@@ -318,7 +330,28 @@ export function isSustainedParticipationDiagnosticsSnapshot(
 export function isCurrentTrackingSnapshot(value: unknown): value is CurrentTrackingSnapshot {
   return isRecord(value)
     && isTrackingWindowSnapshot(value.window)
-    && isTrackingStatusSnapshot(value.status);
+    && isTrackingStatusSnapshot(value.status)
+    && (
+      value.sampledAtMs === undefined
+      || typeof value.sampledAtMs === "number"
+    )
+    && (
+      value.probeStatus === undefined
+      || isEnumValue(value.probeStatus, [
+        "ok",
+        "timeout-fallback",
+        "timeout-inactive",
+        "backing-off-fallback",
+        "backing-off-inactive",
+        "task-failed-fallback",
+        "task-failed-inactive",
+      ] as const)
+    )
+    && (
+      value.degradedReason === undefined
+      || value.degradedReason === null
+      || typeof value.degradedReason === "string"
+    );
 }
 
 export function isTrackingDataChangedPayload(value: unknown): value is TrackingDataChangedPayload {

--- a/tests/trackingLifecycle/runtimeEffects.ts
+++ b/tests/trackingLifecycle/runtimeEffects.ts
@@ -97,7 +97,7 @@ export function runRuntimeEffectsTests() {
       changed_at_ms: "123",
     }), false);
 
-    assert.equal(isRawCurrentTrackingSnapshot({
+    const validCurrentTrackingSnapshot = {
       window: {
         hwnd: "0x100",
         root_owner_hwnd: "0x100",
@@ -148,7 +148,18 @@ export function runRuntimeEffectsTests() {
           },
         },
       },
+    };
+    assert.equal(isRawCurrentTrackingSnapshot(validCurrentTrackingSnapshot), true);
+    assert.equal(isRawCurrentTrackingSnapshot({
+      ...validCurrentTrackingSnapshot,
+      sampled_at_ms: 123,
+      probe_status: "timeout-fallback",
+      degraded_reason: "active window poll timed out after 3 seconds",
     }), true);
+    assert.equal(isRawCurrentTrackingSnapshot({
+      ...validCurrentTrackingSnapshot,
+      probe_status: "timeout",
+    }), false);
   });
 
   runTest("tracking data changed sealed reasons force refresh without pause setting sync", () => {


### PR DESCRIPTION
## Purpose

Refs #13 #15 

## Changes

- 排查并收敛长时间运行期间未释放的资源
- 修复可能重复创建或长期持有的句柄/监听器/定时任务

## Validation

- [ ] 应用连续运行 24 小时后，Private Bytes 不再持续线性增长
- [ ] 应用连续运行 24 小时后，Handle Count 不再异常跳升并长期维持高位
- [ ] CPU 使用率在空闲状态下保持稳定
- [ ] Thread Count 不出现持续增长
- [ ] Dashboard、History、App Mapping、Settings 核心流程可正常使用
- [ ] `npm test` 通过
- [ ] `npm run test:replay` 通过
- [ ] `npm run build` 通过

## Contributor Checklist

- [x] I read the relevant active project documents under `docs/`.
- [x] This pull request solves one coherent problem and excludes unrelated cleanup.
- [x] New behavior is placed under the correct owner and does not bypass architecture boundaries.
- [x] I rebased onto the latest `main`, or confirmed that the branch is compatible with it.
- [x] I documented security behavior for any local or network interface.
- [x] I used `Refs #N` instead of an issue-closing keyword unless explicitly requested.
