### PR TITLE
fix: 修复重复的 `REMOTE_STATUS_BRIDGE_TOKEN` 输入框

### DIFF
--- a/docs/examples/remote-status-bridge-worker/README.md
+++ b/docs/examples/remote-status-bridge-worker/README.md
@@ -12,7 +12,7 @@ It receives Patina `snapshot` messages over WebSocket and keeps the latest state
 ## Setup
 
 1. Deploy this Worker.
-2. Set `REMOTE_STATUS_BRIDGE_TOKEN` to a random value.
+2. Set the `REMOTE_STATUS_BRIDGE_TOKEN` secret to a random value.
 3. In Patina, set the Endpoint URL to `wss://<your-worker-host>/ws`.
 4. In Patina, set the access token to the same value.
 
@@ -28,6 +28,7 @@ npm run dev
 
 ```bash
 npm install
+wrangler secret put REMOTE_STATUS_BRIDGE_TOKEN
 npm run deploy
 ```
 

--- a/docs/examples/remote-status-bridge-worker/wrangler.jsonc
+++ b/docs/examples/remote-status-bridge-worker/wrangler.jsonc
@@ -3,9 +3,6 @@
   "name": "patina-remote-status-bridge",
   "main": "src/index.js",
   "compatibility_date": "2026-06-17",
-  "vars": {
-    "REMOTE_STATUS_BRIDGE_TOKEN": "change-me"
-  },
   "observability": {
     "enabled": true
   }

--- a/docs/examples/remote-status-bridge.md
+++ b/docs/examples/remote-status-bridge.md
@@ -7,7 +7,7 @@
 快速部署：
 
 1. 点击 `Deploy to Cloudflare` 按钮，按照提示创建 Worker。
-2. 在 Worker 中把 `REMOTE_STATUS_BRIDGE_TOKEN` 改成自己的访问令牌。
+2. 在部署页面把 `REMOTE_STATUS_BRIDGE_TOKEN` 填成自己的访问令牌。
 3. 在 Patina 设置页填写 `wss://<your-worker-host>/ws` 和相同的访问令牌。
 
 示例 Worker 位于 `docs/examples/remote-status-bridge-worker`。默认只用内存保存当前状态，不接 `D1` 或 `KV`。
@@ -67,7 +67,7 @@ Worker 必须提供一个可升级为 `WebSocket` 的地址。这个地址可以
 wss://<your-worker-host>/ws
 ```
 
-再把 Worker 的 `REMOTE_STATUS_BRIDGE_TOKEN` 设置成和 Patina `访问令牌` 相同的值。
+再把 Worker 的 `REMOTE_STATUS_BRIDGE_TOKEN` secret 设置成和 Patina `访问令牌` 相同的值。
 
 连接建立后，Patina 会先发送鉴权消息：
 


### PR DESCRIPTION
如图，重复出现了两次。此 PR 已修复

<img width="762" height="353" alt="image" src="https://github.com/user-attachments/assets/23dea8d2-c36c-4b1f-b64b-0b59dafaf3ae" />

Refs #21 