### PR TITLE
fix: 优化相关页面渲染与搜索计算

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:classification": "node --experimental-strip-types --experimental-specifier-resolution=node tests/classificationDraftState.test.ts",
     "test:icon-colors": "node --experimental-strip-types --experimental-specifier-resolution=node tests/iconThemeColors.test.ts",
     "test:dashboard-icons": "node --experimental-strip-types --experimental-specifier-resolution=node tests/dashboardIconRuntimeCache.test.ts",
-    "test:data": "node --experimental-strip-types --experimental-specifier-resolution=node tests/dataReadModel.test.ts && node --experimental-strip-types --experimental-specifier-resolution=node tests/dataFirstPaintScheduler.test.ts",
+    "test:data": "node --experimental-strip-types --experimental-specifier-resolution=node tests/dataReadModel.test.ts && node --experimental-strip-types --experimental-specifier-resolution=node tests/dataFirstPaintScheduler.test.ts && node --experimental-strip-types --experimental-specifier-resolution=node tests/dataAppSearch.test.ts",
     "test:data-range": "node --experimental-strip-types --experimental-specifier-resolution=node tests/dataTrendRange.test.ts",
     "test:data-chart": "node --experimental-strip-types --experimental-specifier-resolution=node tests/dataChartInteraction.test.ts",
     "test:persistence": "node --experimental-strip-types --experimental-specifier-resolution=node tests/persistenceTransaction.test.ts",

--- a/src/features/data/components/Data.tsx
+++ b/src/features/data/components/Data.tsx
@@ -1,6 +1,5 @@
-import { type MouseEvent, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { BarChart3, Search } from "lucide-react";
-import { Area, AreaChart, CartesianGrid, ResponsiveContainer, XAxis, YAxis } from "recharts";
+import { type MouseEvent, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { BarChart3 } from "lucide-react";
 import { UI_TEXT } from "../../../shared/copy/index.ts";
 import { useRequestedAppIcons } from "../../../shared/hooks/useRequestedAppIcons.ts";
 import type { AppLanguage } from "../../../shared/settings/appSettings.ts";
@@ -14,7 +13,6 @@ import {
   buildYearOptions,
   getCachedDataHeatmapSessions,
   getCachedEarliestSessionStartTime,
-  type DataAppOption,
   type DataAppTrendViewModel,
   type DataTrendViewModel,
   type AggregateSessionRecord,
@@ -28,21 +26,21 @@ import {
   type DataBootstrapSnapshot,
 } from "../services/dataBootstrapSnapshot.ts";
 import { prewarmDataFirstScreen } from "../services/dataFirstScreenPrewarm.ts";
-import QuietChartTooltip from "../../../shared/components/QuietChartTooltip";
 import QuietPageHeader from "../../../shared/components/QuietPageHeader";
 import type { TrackerHealthSnapshot } from "../../../shared/types/tracking";
-import {
-  formatChartHours,
-  formatDuration,
-} from "../../history/services/historyFormatting";
 import { resolveTrendDateFromChartEvent } from "../services/dataChartInteraction.ts";
 import type { DataTrendSnapshot } from "../services/dataTrendSnapshot.ts";
 import type { DataTrendRangeSelection } from "../services/dataTrendRange.ts";
 import { useDataTrendSnapshot } from "../hooks/useDataTrendSnapshot.ts";
 import { loadDataIconsForExecutables } from "../services/dataIconService.ts";
 import { scheduleDataWorkAfterFirstPaint } from "../services/dataFirstPaintScheduler.ts";
-import DataTrendRangeControl from "./DataTrendRangeControl.tsx";
+import {
+  dedupeDataAppOptions,
+  filterDataAppOptionsForQuery,
+  resolveDataAppSearchSelection,
+} from "../services/dataAppSearch.ts";
 import DataTrendPanel from "./DataTrendPanel.tsx";
+import DataAppTrendPanel from "./DataAppTrendPanel.tsx";
 import DataHeatmapPanel, { type HeatmapGranularity } from "./DataHeatmapPanel.tsx";
 
 interface Props {
@@ -55,48 +53,6 @@ interface Props {
   uiLanguage: AppLanguage;
 }
 
-function getAppInitial(appName: string) {
-  const trimmed = appName.trim();
-  return trimmed ? trimmed.charAt(0).toUpperCase() : "?";
-}
-
-function getDataAppOptionDisplayKey(app: DataAppOption) {
-  return `${app.appName.trim().toLowerCase().replace(/\s+/g, " ")}|${app.exeName.trim().toLowerCase()}`;
-}
-
-function dedupeDataAppOptions(options: DataAppOption[]) {
-  const merged = new Map<string, DataAppOption>();
-
-  for (const app of options) {
-    const key = getDataAppOptionDisplayKey(app);
-    const existing = merged.get(key);
-
-    if (!existing) {
-      merged.set(key, { ...app });
-      continue;
-    }
-
-    existing.totalDuration += app.totalDuration;
-    existing.percentage += app.percentage;
-    existing.averageDuration += app.averageDuration;
-    existing.activeDayCount = Math.max(existing.activeDayCount, app.activeDayCount);
-  }
-
-  return Array.from(merged.values()).sort((left, right) => right.totalDuration - left.totalDuration);
-}
-
-function filterDataAppOptionsForQuery(options: DataAppOption[], query: string) {
-  const normalizedQuery = query.trim().toLowerCase();
-  const dedupedOptions = dedupeDataAppOptions(options);
-  if (!normalizedQuery) return dedupedOptions;
-
-  return dedupedOptions.filter((app) => (
-    app.appName.toLowerCase().includes(normalizedQuery)
-    || app.exeName.toLowerCase().includes(normalizedQuery)
-  ));
-}
-
-const DATA_TREND_X_AXIS_MIN_TICK_GAP = 24;
 type DataChartDimension = { width: number; height: number };
 type DataChartDimensionKey = "overviewTrend" | "appTrend";
 const CACHED_DATA_HEATMAP_REFRESH_DELAY_MS = 320;
@@ -429,10 +385,13 @@ export default function Data({
     }
   }, [appTrendViewModel?.selectedApp?.appKey, selectedAppKey]);
 
-  const filteredAppOptions = useMemo(() => {
+  const dedupedAppOptions = useMemo(() => {
     if (!visibleAppTrendViewModel) return [];
-    return filterDataAppOptionsForQuery(visibleAppTrendViewModel.appOptions, appSearchQuery);
-  }, [appSearchQuery, visibleAppTrendViewModel]);
+    return dedupeDataAppOptions(visibleAppTrendViewModel.appOptions);
+  }, [visibleAppTrendViewModel?.appOptions]);
+  const filteredAppOptions = useMemo(() => (
+    filterDataAppOptionsForQuery(dedupedAppOptions, appSearchQuery)
+  ), [appSearchQuery, dedupedAppOptions]);
 
   const hasAppSearchQuery = appSearchQuery.trim().length > 0;
   const appTrendSelectedAppMatchesSearch = !hasAppSearchQuery
@@ -448,18 +407,18 @@ export default function Data({
   const appTrendChartAxis = appTrendSelectionHiddenBySearch
     ? { domainMax: 3, ticks: [0, 1, 2, 3] }
     : (visibleAppTrendViewModel?.chartAxis ?? { domainMax: 3, ticks: [0, 1, 2, 3] });
-  const appTrendPeakDay = appTrendSelectionHiddenBySearch ? null : visibleAppTrendViewModel?.peakDay;
+  const appTrendPeakDay = appTrendSelectionHiddenBySearch ? null : (visibleAppTrendViewModel?.peakDay ?? null);
 
   useEffect(() => {
     if (!hasAppSearchQuery || !visibleAppTrendViewModel) return;
-    const firstMatch = filteredAppOptions[0];
-    if (!firstMatch) return;
-    const selectedAppKeyIsVisible = Boolean(
-      visibleAppTrendViewModel.selectedApp
-      && filteredAppOptions.some((app) => app.appKey === visibleAppTrendViewModel.selectedApp?.appKey),
-    );
-    const nextSelectedAppKey = selectedAppKeyIsVisible ? selectedAppKey : firstMatch.appKey;
-    if (selectedAppKey !== nextSelectedAppKey) {
+    const nextSelectedAppKey = resolveDataAppSearchSelection({
+      wasSearching: false,
+      isSearching: hasAppSearchQuery,
+      selectedAppKey,
+      selectedApp: visibleAppTrendViewModel.selectedApp,
+      filteredOptions: filteredAppOptions,
+    });
+    if (nextSelectedAppKey !== undefined && selectedAppKey !== nextSelectedAppKey) {
       setSelectedAppKey(nextSelectedAppKey);
     }
   }, [filteredAppOptions, hasAppSearchQuery, selectedAppKey, visibleAppTrendViewModel]);
@@ -468,28 +427,27 @@ export default function Data({
     appListRef.current?.scrollTo({ top: 0 });
   }, [hasAppSearchQuery]);
 
-  const handleAppSearchQueryChange = (nextQuery: string) => {
+  const handleAppSearchQueryChange = useCallback((nextQuery: string) => {
     const wasSearching = appSearchQuery.trim().length > 0;
     const isSearching = nextQuery.trim().length > 0;
     setAppSearchQuery(nextQuery);
     appListRef.current?.scrollTo({ top: 0 });
-    if (wasSearching && !isSearching) {
-      setSelectedAppKey(null);
-      return;
+    const nextSelectedAppKey = resolveDataAppSearchSelection({
+      wasSearching,
+      isSearching,
+      selectedAppKey,
+      selectedApp: visibleAppTrendViewModel?.selectedApp,
+      filteredOptions: filterDataAppOptionsForQuery(dedupedAppOptions, nextQuery),
+    });
+    if (nextSelectedAppKey !== undefined && selectedAppKey !== nextSelectedAppKey) {
+      setSelectedAppKey(nextSelectedAppKey);
     }
-
-    if (isSearching && visibleAppTrendViewModel) {
-      const nextOptions = filterDataAppOptionsForQuery(visibleAppTrendViewModel.appOptions, nextQuery);
-      const selectedAppKeyIsVisible = Boolean(
-        visibleAppTrendViewModel.selectedApp
-        && nextOptions.some((app) => app.appKey === visibleAppTrendViewModel.selectedApp?.appKey),
-      );
-      const firstMatch = nextOptions[0];
-      if (!selectedAppKeyIsVisible && firstMatch) {
-        setSelectedAppKey(firstMatch.appKey);
-      }
-    }
-  };
+  }, [
+    appSearchQuery,
+    dedupedAppOptions,
+    selectedAppKey,
+    visibleAppTrendViewModel?.selectedApp,
+  ]);
   const heatmapRows = useMemo(() => (
     buildActivityHeatmap(yearSessions, selectedHeatmapView, nowMs)
   ), [nowMs, selectedHeatmapView, yearSessions]);
@@ -557,17 +515,17 @@ export default function Data({
       onOpenHistoryDate?.(dateKey);
     }
   };
-  const handleAppTrendMouseMove = (event: unknown) => {
+  const handleAppTrendMouseMove = useCallback((event: unknown) => {
     activeAppTrendDateRef.current = canOpenAppTrendHistory
       ? resolveTrendDateFromChartEvent(event, appTrendChartData)
       : null;
-  };
-  const handleAppTrendDoubleClick = () => {
+  }, [appTrendChartData, canOpenAppTrendHistory]);
+  const handleAppTrendDoubleClick = useCallback(() => {
     const dateKey = activeAppTrendDateRef.current;
     if (dateKey && canOpenAppTrendHistory) {
       onOpenHistoryDate?.(dateKey);
     }
-  };
+  }, [canOpenAppTrendHistory, onOpenHistoryDate]);
   const preventChartTextSelection = (event: MouseEvent<HTMLDivElement>, canOpenHistory: boolean) => {
     if (canOpenHistory && event.detail > 1) {
       event.preventDefault();
@@ -581,14 +539,20 @@ export default function Data({
     event.preventDefault();
     handleTrendDoubleClick();
   };
-  const handleAppTrendDoubleClickCapture = (event: MouseEvent<HTMLDivElement>) => {
+  const handleAppTrendDoubleClickCapture = useCallback((event: MouseEvent<HTMLDivElement>) => {
     if (!canOpenAppTrendHistory) {
       return;
     }
 
     event.preventDefault();
     handleAppTrendDoubleClick();
-  };
+  }, [canOpenAppTrendHistory, handleAppTrendDoubleClick]);
+  const handleAppTrendMouseDownCapture = useCallback((event: MouseEvent<HTMLDivElement>) => {
+    preventChartTextSelection(event, canOpenAppTrendHistory);
+  }, [canOpenAppTrendHistory]);
+  const handleAppTrendMouseLeave = useCallback(() => {
+    activeAppTrendDateRef.current = null;
+  }, []);
 
   useEffect(() => {
     if (!trendViewModel || !appTrendViewModel) return;
@@ -666,203 +630,29 @@ export default function Data({
         />
       </div>
 
-      <div className="qp-panel p-5 data-app-panel">
-        <div className="data-app-panel-header">
-          <div>
-            <h3 className="font-semibold text-[var(--qp-text-primary)] text-sm">
-              {UI_TEXT.data.appTrend}
-            </h3>
-          </div>
-          <div className="data-app-header-actions">
-            <div className={`data-app-selected-status ${selectedAppTrendApp ? "" : "data-app-selected-status-empty"}`}>
-              {selectedAppTrendApp && dataIcons[selectedAppTrendApp.exeName] ? (
-                <img
-                  src={dataIcons[selectedAppTrendApp.exeName]}
-                  alt=""
-                  draggable={false}
-                />
-              ) : selectedAppTrendApp ? (
-                getAppInitial(selectedAppTrendApp.appName)
-              ) : (
-                ""
-              )}
-            </div>
-            <DataTrendRangeControl
-              ariaLabel={UI_TEXT.accessibility.data.appTrendRange}
-              selection={selectedAppTrendRange}
-              onChange={setSelectedAppTrendRange}
-            />
-          </div>
-        </div>
-
-        {!visibleAppTrendViewModel ? (
-          <div className="data-app-grid invisible pointer-events-none select-none" aria-hidden="true">
-            <div className="data-app-sidebar">
-              <div className="data-app-search" />
-              <div className="data-app-list data-app-trend-list" />
-            </div>
-            <div className="data-app-chart-column">
-              <div className="data-app-metric-strip">
-                <div className="data-app-metric">
-                  <span>-</span>
-                  <strong>-</strong>
-                </div>
-                <div className="data-app-metric">
-                  <span>-</span>
-                  <strong>-</strong>
-                </div>
-                <div className="data-app-metric">
-                  <span>-</span>
-                  <strong>-</strong>
-                </div>
-                <div className="data-app-metric">
-                  <span>-</span>
-                  <strong>-</strong>
-                </div>
-              </div>
-              <div
-                ref={appTrendChart.chartRef}
-                className="data-app-chart data-chart-placeholder"
-              />
-            </div>
-          </div>
-        ) : visibleAppTrendViewModel.appOptions.length === 0 ? (
-          <div className="data-app-loading text-[var(--qp-text-tertiary)] text-xs">
-            {UI_TEXT.data.appTrendEmpty}
-          </div>
-        ) : (
-          <div className="data-app-grid">
-            <div className="data-app-sidebar">
-              <label className="data-app-search">
-                <Search size={14} aria-hidden />
-                <input
-                  value={appSearchQuery}
-                  onChange={(event) => handleAppSearchQueryChange(event.target.value)}
-                  placeholder={UI_TEXT.data.appSearchPlaceholder}
-                  aria-label={UI_TEXT.data.appSearchPlaceholder}
-                />
-              </label>
-              <div
-                key={hasAppSearchQuery ? "searching" : "all"}
-                ref={appListRef}
-                className="data-app-list data-app-trend-list"
-                aria-label={UI_TEXT.data.appTrendAppList}
-              >
-                {filteredAppOptions.length === 0 ? (
-                  <div className="data-app-empty text-[var(--qp-text-tertiary)] text-xs">
-                    {UI_TEXT.data.appTrendNoMatch}
-                  </div>
-                ) : filteredAppOptions.map((app) => {
-                  const isSelected = selectedAppTrendApp?.appKey === app.appKey;
-                  return (
-                    <button
-                      key={app.appKey}
-                      type="button"
-                      className={`data-app-option ${isSelected ? "data-app-option-selected" : ""}`}
-                      onClick={() => setSelectedAppKey(app.appKey)}
-                      aria-pressed={isSelected}
-                    >
-                      <span className="data-app-option-icon" aria-hidden>
-                        {dataIcons[app.exeName] ? (
-                          <img src={dataIcons[app.exeName]} alt="" draggable={false} />
-                        ) : (
-                          getAppInitial(app.appName)
-                        )}
-                      </span>
-                      <span className="data-app-option-main">
-                        <span className="data-app-option-name">{app.appName}</span>
-                        <span className="data-app-option-meta">{Math.round(app.percentage)}% · {app.exeName}</span>
-                      </span>
-                      <span className="data-app-option-duration">
-                        {formatDuration(app.totalDuration)}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-
-            <div className="data-app-chart-column">
-              <div className="data-app-metric-strip">
-                <div className="data-app-metric">
-                  <span>{UI_TEXT.data.appTrendTotal}</span>
-                  <strong>{formatDuration(selectedAppTrendApp?.totalDuration ?? 0)}</strong>
-                </div>
-                <div className="data-app-metric">
-                  <span>{visibleAppTrendViewModel.granularity === "month" ? UI_TEXT.data.monthlyAverage : UI_TEXT.data.appTrendAverage}</span>
-                  <strong>{formatDuration(selectedAppTrendApp?.averageDuration ?? 0)}</strong>
-                </div>
-                <div className="data-app-metric">
-                  <span>{UI_TEXT.data.appTrendActiveDays}</span>
-                  <strong>{selectedAppTrendApp?.activeDayCount ?? 0}</strong>
-                </div>
-                <div className="data-app-metric">
-                  <span>{UI_TEXT.data.appTrendPeakDay}</span>
-                  <strong>{appTrendPeakDay ? formatDuration(appTrendPeakDay.duration) : "-"}</strong>
-                </div>
-              </div>
-              <div
-                ref={appTrendChart.chartRef}
-                className={`data-app-chart ${canOpenAppTrendHistory ? "data-chart-openable" : ""}`}
-                onMouseDownCapture={(event) => {
-                  preventChartTextSelection(event, canOpenAppTrendHistory);
-                }}
-                onDoubleClickCapture={handleAppTrendDoubleClickCapture}
-              >
-                <ResponsiveContainer
-                  width="100%"
-                  height="100%"
-                  initialDimension={appTrendChart.initialDimension}
-                >
-                  <AreaChart
-                    data={appTrendChartData}
-                    margin={{ top: 10, right: 18, left: -20, bottom: 0 }}
-                    onMouseMove={handleAppTrendMouseMove}
-                    onMouseLeave={() => {
-                      activeAppTrendDateRef.current = null;
-                    }}
-                  >
-                    <CartesianGrid strokeDasharray="3 3" stroke="var(--qp-border-subtle)" strokeOpacity={0.58} />
-                    <XAxis
-                      dataKey="label"
-                      tick={{ fontSize: 10, fill: "var(--qp-text-tertiary)" }}
-                      axisLine={false}
-                      tickLine={false}
-                      interval="preserveStartEnd"
-                      minTickGap={DATA_TREND_X_AXIS_MIN_TICK_GAP}
-                    />
-                    <YAxis
-                      tick={{ fontSize: 10, fill: "var(--qp-text-tertiary)" }}
-                      axisLine={false}
-                      tickLine={false}
-                      ticks={appTrendChartAxis.ticks}
-                      domain={[0, appTrendChartAxis.domainMax]}
-                      tickFormatter={(value) => formatChartHours(Number(value))}
-                    />
-                    <QuietChartTooltip
-                      formatter={(value) => [
-                        formatDuration(Number(value) * 3600000),
-                        UI_TEXT.data.appTrendUsage,
-                      ]}
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="hours"
-                      stroke="var(--qp-accent-default)"
-                      strokeWidth={2}
-                      fill="var(--qp-accent-default)"
-                      fillOpacity={0.1}
-                      dot={{ fill: "var(--qp-accent-default)", r: 2.5 }}
-                      isAnimationActive={false}
-                    />
-                  </AreaChart>
-                </ResponsiveContainer>
-              </div>
-            </div>
-
-          </div>
-        )}
-      </div>
+      <DataAppTrendPanel
+        selection={selectedAppTrendRange}
+        viewModel={visibleAppTrendViewModel}
+        selectedApp={selectedAppTrendApp}
+        filteredAppOptions={filteredAppOptions}
+        appSearchQuery={appSearchQuery}
+        hasAppSearchQuery={hasAppSearchQuery}
+        chartData={appTrendChartData}
+        chartAxis={appTrendChartAxis}
+        peakDay={appTrendPeakDay}
+        dataIcons={dataIcons}
+        appListRef={appListRef}
+        chartRef={appTrendChart.chartRef}
+        initialDimension={appTrendChart.initialDimension}
+        canOpenHistory={canOpenAppTrendHistory}
+        onSelectionChange={setSelectedAppTrendRange}
+        onSearchQueryChange={handleAppSearchQueryChange}
+        onAppSelect={setSelectedAppKey}
+        onMouseDownCapture={handleAppTrendMouseDownCapture}
+        onDoubleClickCapture={handleAppTrendDoubleClickCapture}
+        onMouseMove={handleAppTrendMouseMove}
+        onMouseLeave={handleAppTrendMouseLeave}
+      />
       </div>
     </div>
   );

--- a/src/features/data/components/Data.tsx
+++ b/src/features/data/components/Data.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { startTransition, type MouseEvent, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { BarChart3 } from "lucide-react";
 import { UI_TEXT } from "../../../shared/copy/index.ts";
 import { useRequestedAppIcons } from "../../../shared/hooks/useRequestedAppIcons.ts";
@@ -59,6 +59,14 @@ const CACHED_DATA_HEATMAP_REFRESH_DELAY_MS = 320;
 const CACHED_DATA_HEATMAP_REFRESH_IDLE_TIMEOUT_MS = 1_500;
 const DATA_OPEN_PREWARM_DELAY_MS = 500;
 const DATA_OPEN_PREWARM_IDLE_TIMEOUT_MS = 2_000;
+const EMPTY_DATA_ICON_EXE_NAMES: string[] = [];
+const EMPTY_DATA_APP_OPTIONS: DataAppTrendViewModel["appOptions"] = [];
+const EMPTY_DATA_APP_TREND_POINTS: DataAppTrendViewModel["chartData"] = [];
+const EMPTY_HEATMAP_ROWS: ReturnType<typeof buildActivityHeatmap> = [];
+const DEFAULT_DATA_APP_CHART_AXIS: DataAppTrendViewModel["chartAxis"] = {
+  domainMax: 3,
+  ticks: [0, 1, 2, 3],
+};
 const dataChartDimensionCache: Partial<Record<DataChartDimensionKey, DataChartDimension>> = {};
 const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
@@ -154,7 +162,8 @@ export default function Data({
   const [selectedAppTrendRange, setSelectedAppTrendRange] = useState<DataTrendRangeSelection>({ kind: "rolling", days: 7 });
   const [selectedAppKey, setSelectedAppKey] = useState<string | null>(null);
   const [appSearchQuery, setAppSearchQuery] = useState("");
-  const initialCachedHeatmapSessions = getCachedDataHeatmapSessions("recent", Date.now());
+  const [freshReadModelsReady, setFreshReadModelsReady] = useState(false);
+  const [initialCachedHeatmapSessions] = useState(() => getCachedDataHeatmapSessions("recent", Date.now()));
   const [bootstrapSnapshot, setBootstrapSnapshot] = useState<DataBootstrapSnapshot | null>(
     () => getCachedDataBootstrapSnapshot(),
   );
@@ -205,6 +214,7 @@ export default function Data({
   const hasFetchedHeatmapOnceRef = useRef(Boolean(initialCachedHeatmapSessions));
   const activeTrendDateRef = useRef<string | null>(null);
   const activeAppTrendDateRef = useRef<string | null>(null);
+  const hasInitialBootstrapSnapshotRef = useRef(Boolean(bootstrapSnapshot));
 
   useEffect(() => {
     if (bootstrapSnapshot) return;
@@ -240,15 +250,19 @@ export default function Data({
         const snapshot = await loadDataHeatmapSnapshot(selectedHeatmapView, nowForRange);
         if (cancelled) return;
 
-        setEarliestStartTime(snapshot.earliestStartTime);
-        setYearSessions(snapshot.sessions);
-        setYearSessionsView(selectedHeatmapView);
+        startTransition(() => {
+          setEarliestStartTime(snapshot.earliestStartTime);
+          setYearSessions(snapshot.sessions);
+          setYearSessionsView(selectedHeatmapView);
+        });
         hasFetchedHeatmapOnceRef.current = true;
 
         if (snapshot.earliestStartTime) {
           const earliestYear = new Date(snapshot.earliestStartTime).getFullYear();
           if (selectedHeatmapView !== "recent" && selectedHeatmapView < earliestYear) {
-            setSelectedHeatmapView(earliestYear);
+            startTransition(() => {
+              setSelectedHeatmapView(earliestYear);
+            });
           }
         }
       } finally {
@@ -262,8 +276,10 @@ export default function Data({
       const cachedSessions = getCachedDataHeatmapSessions(selectedHeatmapView, nowForRange);
 
       if (cachedSessions) {
-        setYearSessions(cachedSessions);
-        setYearSessionsView(selectedHeatmapView);
+        startTransition(() => {
+          setYearSessions(cachedSessions);
+          setYearSessionsView(selectedHeatmapView);
+        });
         hasFetchedHeatmapOnceRef.current = true;
         setHeatmapLoading(false);
       } else {
@@ -287,45 +303,77 @@ export default function Data({
     };
   }, [selectedHeatmapView, refreshKey]);
 
+  const matchingBootstrapSnapshot = bootstrapSnapshot
+    && bootstrapSnapshot.mappingVersion === mappingVersion
+    && bootstrapSnapshot.uiLanguage === uiLanguage
+    ? bootstrapSnapshot
+    : null;
+  const shouldDeferRuntimeReadModels = hasInitialBootstrapSnapshotRef.current
+    && Boolean(matchingBootstrapSnapshot)
+    && !freshReadModelsReady;
+  const overviewTrendSnapshotForViewModel = shouldDeferRuntimeReadModels ? null : overviewTrend.snapshot;
+  const appTrendSnapshotForViewModel = shouldDeferRuntimeReadModels ? null : appTrend.snapshot;
+
+  useEffect(() => {
+    if (!hasInitialBootstrapSnapshotRef.current || !matchingBootstrapSnapshot || freshReadModelsReady) {
+      return undefined;
+    }
+
+    return scheduleDataWorkAfterFirstPaint(() => {
+      setFreshReadModelsReady(true);
+    });
+  }, [freshReadModelsReady, matchingBootstrapSnapshot]);
+
   const sharedTrendAggregateContext = useMemo(() => {
-    if (!overviewTrend.snapshot || !appTrend.snapshot) return null;
-    const overviewRange = overviewTrend.snapshot.range;
-    const appRange = appTrend.snapshot.range;
+    if (!overviewTrendSnapshotForViewModel || !appTrendSnapshotForViewModel) return null;
+    const overviewRange = overviewTrendSnapshotForViewModel.range;
+    const appRange = appTrendSnapshotForViewModel.range;
     if (
       overviewRange.cacheKey !== appRange.cacheKey
       || overviewRange.label !== appRange.label
       || overviewRange.granularity !== appRange.granularity
       || overviewRange.dayCount !== appRange.dayCount
-      || overviewTrend.snapshot.sessions !== appTrend.snapshot.sessions
+      || overviewTrendSnapshotForViewModel.sessions !== appTrendSnapshotForViewModel.sessions
     ) {
       return null;
     }
 
     return buildDataTrendAggregateContext(
-      overviewTrend.snapshot.sessions,
+      overviewTrendSnapshotForViewModel.sessions,
       overviewRange,
       overviewTrend.nowMs,
     );
-  }, [appTrend.snapshot, mappingVersion, overviewTrend.nowMs, overviewTrend.snapshot, uiLanguage]);
+  }, [
+    appTrendSnapshotForViewModel,
+    mappingVersion,
+    overviewTrend.nowMs,
+    overviewTrendSnapshotForViewModel,
+    uiLanguage,
+  ]);
 
   const trendViewModel = useMemo(() => {
     if (sharedTrendAggregateContext) {
       return buildDataTrendViewModelFromAggregate(sharedTrendAggregateContext);
     }
-    if (!overviewTrend.snapshot) return null;
-    return buildDataTrendViewModel(overviewTrend.snapshot.sessions, overviewTrend.snapshot.range, overviewTrend.nowMs);
-  }, [mappingVersion, overviewTrend.nowMs, overviewTrend.snapshot, sharedTrendAggregateContext, uiLanguage]);
+    if (!overviewTrendSnapshotForViewModel) return null;
+    return buildDataTrendViewModel(
+      overviewTrendSnapshotForViewModel.sessions,
+      overviewTrendSnapshotForViewModel.range,
+      overviewTrend.nowMs,
+    );
+  }, [
+    mappingVersion,
+    overviewTrend.nowMs,
+    overviewTrendSnapshotForViewModel,
+    sharedTrendAggregateContext,
+    uiLanguage,
+  ]);
   if (trendViewModel) {
     lastTrendViewModelRef.current = {
       rangeCacheKey: overviewTrend.resolvedRange.cacheKey,
       viewModel: trendViewModel,
     };
   }
-  const matchingBootstrapSnapshot = bootstrapSnapshot
-    && bootstrapSnapshot.mappingVersion === mappingVersion
-    && bootstrapSnapshot.uiLanguage === uiLanguage
-    ? bootstrapSnapshot
-    : null;
   const bootstrapTrendViewModel = matchingBootstrapSnapshot?.overviewRangeCacheKey === overviewTrend.resolvedRange.cacheKey
     ? matchingBootstrapSnapshot.overviewTrendViewModel
     : null;
@@ -338,9 +386,21 @@ export default function Data({
     if (sharedTrendAggregateContext) {
       return buildDataAppTrendViewModelFromAggregate(sharedTrendAggregateContext, selectedAppKey);
     }
-    if (!appTrend.snapshot) return null;
-    return buildDataAppTrendViewModel(appTrend.snapshot.sessions, appTrend.snapshot.range, appTrend.nowMs, selectedAppKey);
-  }, [appTrend.nowMs, appTrend.snapshot, mappingVersion, selectedAppKey, sharedTrendAggregateContext, uiLanguage]);
+    if (!appTrendSnapshotForViewModel) return null;
+    return buildDataAppTrendViewModel(
+      appTrendSnapshotForViewModel.sessions,
+      appTrendSnapshotForViewModel.range,
+      appTrend.nowMs,
+      selectedAppKey,
+    );
+  }, [
+    appTrend.nowMs,
+    appTrendSnapshotForViewModel,
+    mappingVersion,
+    selectedAppKey,
+    sharedTrendAggregateContext,
+    uiLanguage,
+  ]);
   const bootstrapAppTrendViewModel = matchingBootstrapSnapshot?.appRangeCacheKey === appTrend.resolvedRange.cacheKey
     ? matchingBootstrapSnapshot.appTrendViewModel
     : null;
@@ -356,8 +416,8 @@ export default function Data({
       : null)
     ?? bootstrapAppTrendViewModel;
   const dataIconExeNames = useMemo(
-    () => visibleAppTrendViewModel?.appOptions.map((app) => app.exeName) ?? [],
-    [visibleAppTrendViewModel],
+    () => visibleAppTrendViewModel?.appOptions.map((app) => app.exeName) ?? EMPTY_DATA_ICON_EXE_NAMES,
+    [visibleAppTrendViewModel?.appOptions],
   );
   const snapshotDataIcons = useMemo(() => ({
     ...(overviewTrend.snapshot?.icons ?? {}),
@@ -367,13 +427,14 @@ export default function Data({
     ...icons,
     ...snapshotDataIcons,
   }), [icons, snapshotDataIcons]);
+  const handleDataIconsError = useCallback((error: unknown) => {
+    console.warn("Failed to refresh data app icons:", error);
+  }, []);
   const dataIcons = useRequestedAppIcons({
     baseIcons: baseDataIcons,
     exeNames: dataIconExeNames,
     loadIcons: loadDataIconsForExecutables,
-    onError: (error) => {
-      console.warn("Failed to refresh data app icons:", error);
-    },
+    onError: handleDataIconsError,
   });
 
   useEffect(() => {
@@ -386,7 +447,7 @@ export default function Data({
   }, [appTrendViewModel?.selectedApp?.appKey, selectedAppKey]);
 
   const dedupedAppOptions = useMemo(() => {
-    if (!visibleAppTrendViewModel) return [];
+    if (!visibleAppTrendViewModel) return EMPTY_DATA_APP_OPTIONS;
     return dedupeDataAppOptions(visibleAppTrendViewModel.appOptions);
   }, [visibleAppTrendViewModel?.appOptions]);
   const filteredAppOptions = useMemo(() => (
@@ -401,12 +462,17 @@ export default function Data({
     );
   const appTrendSelectionHiddenBySearch = hasAppSearchQuery && !appTrendSelectedAppMatchesSearch;
   const selectedAppTrendApp = appTrendSelectionHiddenBySearch ? null : visibleAppTrendViewModel?.selectedApp;
-  const appTrendChartData = appTrendSelectionHiddenBySearch && visibleAppTrendViewModel
-    ? visibleAppTrendViewModel.chartData.map((point) => ({ ...point, duration: 0, hours: 0 }))
-    : (visibleAppTrendViewModel?.chartData ?? []);
-  const appTrendChartAxis = appTrendSelectionHiddenBySearch
-    ? { domainMax: 3, ticks: [0, 1, 2, 3] }
-    : (visibleAppTrendViewModel?.chartAxis ?? { domainMax: 3, ticks: [0, 1, 2, 3] });
+  const appTrendChartData = useMemo(() => {
+    if (appTrendSelectionHiddenBySearch && visibleAppTrendViewModel) {
+      return visibleAppTrendViewModel.chartData.map((point) => ({ ...point, duration: 0, hours: 0 }));
+    }
+    return visibleAppTrendViewModel?.chartData ?? EMPTY_DATA_APP_TREND_POINTS;
+  }, [appTrendSelectionHiddenBySearch, visibleAppTrendViewModel?.chartData]);
+  const appTrendChartAxis = useMemo(() => (
+    appTrendSelectionHiddenBySearch
+      ? DEFAULT_DATA_APP_CHART_AXIS
+      : visibleAppTrendViewModel?.chartAxis ?? DEFAULT_DATA_APP_CHART_AXIS
+  ), [appTrendSelectionHiddenBySearch, visibleAppTrendViewModel?.chartAxis]);
   const appTrendPeakDay = appTrendSelectionHiddenBySearch ? null : (visibleAppTrendViewModel?.peakDay ?? null);
 
   useEffect(() => {
@@ -448,11 +514,17 @@ export default function Data({
     selectedAppKey,
     visibleAppTrendViewModel?.selectedApp,
   ]);
-  const heatmapRows = useMemo(() => (
-    buildActivityHeatmap(yearSessions, selectedHeatmapView, nowMs)
-  ), [nowMs, selectedHeatmapView, yearSessions]);
+  const shouldDeferHeatmapRows = Boolean(
+    hasInitialBootstrapSnapshotRef.current
+    && matchingBootstrapSnapshot?.heatmapSelection === selectedHeatmapView
+    && !freshReadModelsReady,
+  );
+  const heatmapRows = useMemo<ReturnType<typeof buildActivityHeatmap> | null>(() => {
+    if (shouldDeferHeatmapRows) return null;
+    return buildActivityHeatmap(yearSessions, selectedHeatmapView, nowMs);
+  }, [nowMs, selectedHeatmapView, shouldDeferHeatmapRows, yearSessions]);
   const hasHeatmapRowsForSelectedView = yearSessionsView === selectedHeatmapView;
-  if (!heatmapLoading && hasHeatmapRowsForSelectedView) {
+  if (heatmapRows && !heatmapLoading && hasHeatmapRowsForSelectedView) {
     lastHeatmapRowsRef.current = {
       selection: selectedHeatmapView,
       rows: heatmapRows,
@@ -461,17 +533,22 @@ export default function Data({
   const bootstrapHeatmapRows = matchingBootstrapSnapshot?.heatmapSelection === selectedHeatmapView
     ? matchingBootstrapSnapshot.heatmapRows
     : null;
+  const freshHeatmapRows = heatmapRows && !heatmapLoading && hasHeatmapRowsForSelectedView ? heatmapRows : null;
+  const lastHeatmapRows = lastHeatmapRowsRef.current?.selection === selectedHeatmapView
+    ? lastHeatmapRowsRef.current.rows
+    : null;
+  const canUseBootstrapHeatmap = Boolean(
+    bootstrapHeatmapRows && (shouldDeferHeatmapRows || heatmapLoading || !hasHeatmapRowsForSelectedView),
+  );
+  const shouldBuildHeatmapPlaceholderRows = !freshHeatmapRows && !lastHeatmapRows && !canUseBootstrapHeatmap;
   const heatmapPlaceholderRows = useMemo(() => (
-    buildActivityHeatmap([], selectedHeatmapView, nowMs)
-  ), [nowMs, selectedHeatmapView]);
-  const canUseBootstrapHeatmap = Boolean(bootstrapHeatmapRows && (heatmapLoading || !hasHeatmapRowsForSelectedView));
-  const visibleHeatmapRows = !heatmapLoading && hasHeatmapRowsForSelectedView
-    ? heatmapRows
-    : lastHeatmapRowsRef.current?.selection === selectedHeatmapView
-      ? lastHeatmapRowsRef.current.rows
-      : canUseBootstrapHeatmap
-    ? bootstrapHeatmapRows!
-        : heatmapPlaceholderRows;
+    shouldBuildHeatmapPlaceholderRows ? buildActivityHeatmap([], selectedHeatmapView, nowMs) : null
+  ), [nowMs, selectedHeatmapView, shouldBuildHeatmapPlaceholderRows]);
+  const visibleHeatmapRows = freshHeatmapRows
+    ?? lastHeatmapRows
+    ?? (canUseBootstrapHeatmap ? bootstrapHeatmapRows : null)
+    ?? heatmapPlaceholderRows
+    ?? EMPTY_HEATMAP_ROWS;
   const heatmapGranularityOptions = useMemo<Array<{ value: HeatmapGranularity; label: string }>>(() => [
     { value: "daily", label: UI_TEXT.data.heatmapDaily },
     { value: "weekly", label: UI_TEXT.data.heatmapWeekly },
@@ -489,14 +566,14 @@ export default function Data({
   const canSelectOlderHeatmapView = selectedHeatmapViewIndex >= 0
     && selectedHeatmapViewIndex < heatmapViewOptions.length - 1;
   const canSelectNewerHeatmapView = selectedHeatmapViewIndex > 0;
-  const selectAdjacentHeatmapView = (delta: number) => {
+  const selectAdjacentHeatmapView = useCallback((delta: number) => {
     if (selectedHeatmapViewIndex < 0) return;
     const nextView = heatmapViewOptions[selectedHeatmapViewIndex + delta];
     if (nextView !== undefined) {
       setHeatmapLoading(true);
       setSelectedHeatmapView(nextView);
     }
-  };
+  }, [heatmapViewOptions, selectedHeatmapViewIndex]);
   const selectedHeatmapViewLabel = selectedHeatmapView === "recent"
     ? UI_TEXT.data.recentYear
     : String(selectedHeatmapView);
@@ -504,17 +581,17 @@ export default function Data({
   const canOpenAppTrendHistory = visibleAppTrendViewModel?.granularity === "day"
     && !appTrendSelectionHiddenBySearch
     && Boolean(onOpenHistoryDate);
-  const handleTrendMouseMove = (event: unknown) => {
+  const handleTrendMouseMove = useCallback((event: unknown) => {
     activeTrendDateRef.current = canOpenTrendHistory && visibleTrendViewModel
       ? resolveTrendDateFromChartEvent(event, visibleTrendViewModel.chartData)
       : null;
-  };
-  const handleTrendDoubleClick = () => {
+  }, [canOpenTrendHistory, visibleTrendViewModel]);
+  const handleTrendDoubleClick = useCallback(() => {
     const dateKey = activeTrendDateRef.current;
     if (dateKey && canOpenTrendHistory) {
       onOpenHistoryDate?.(dateKey);
     }
-  };
+  }, [canOpenTrendHistory, onOpenHistoryDate]);
   const handleAppTrendMouseMove = useCallback((event: unknown) => {
     activeAppTrendDateRef.current = canOpenAppTrendHistory
       ? resolveTrendDateFromChartEvent(event, appTrendChartData)
@@ -526,19 +603,22 @@ export default function Data({
       onOpenHistoryDate?.(dateKey);
     }
   }, [canOpenAppTrendHistory, onOpenHistoryDate]);
-  const preventChartTextSelection = (event: MouseEvent<HTMLDivElement>, canOpenHistory: boolean) => {
+  const preventChartTextSelection = useCallback((event: MouseEvent<HTMLDivElement>, canOpenHistory: boolean) => {
     if (canOpenHistory && event.detail > 1) {
       event.preventDefault();
     }
-  };
-  const handleTrendDoubleClickCapture = (event: MouseEvent<HTMLDivElement>) => {
+  }, []);
+  const handleTrendMouseDownCapture = useCallback((event: MouseEvent<HTMLDivElement>) => {
+    preventChartTextSelection(event, canOpenTrendHistory);
+  }, [canOpenTrendHistory, preventChartTextSelection]);
+  const handleTrendDoubleClickCapture = useCallback((event: MouseEvent<HTMLDivElement>) => {
     if (!canOpenTrendHistory) {
       return;
     }
 
     event.preventDefault();
     handleTrendDoubleClick();
-  };
+  }, [canOpenTrendHistory, handleTrendDoubleClick]);
   const handleAppTrendDoubleClickCapture = useCallback((event: MouseEvent<HTMLDivElement>) => {
     if (!canOpenAppTrendHistory) {
       return;
@@ -549,13 +629,16 @@ export default function Data({
   }, [canOpenAppTrendHistory, handleAppTrendDoubleClick]);
   const handleAppTrendMouseDownCapture = useCallback((event: MouseEvent<HTMLDivElement>) => {
     preventChartTextSelection(event, canOpenAppTrendHistory);
-  }, [canOpenAppTrendHistory]);
+  }, [canOpenAppTrendHistory, preventChartTextSelection]);
+  const handleTrendMouseLeave = useCallback(() => {
+    activeTrendDateRef.current = null;
+  }, []);
   const handleAppTrendMouseLeave = useCallback(() => {
     activeAppTrendDateRef.current = null;
   }, []);
 
   useEffect(() => {
-    if (!trendViewModel || !appTrendViewModel) return;
+    if (!trendViewModel || !appTrendViewModel || !heatmapRows) return;
     if (heatmapLoading || yearSessionsView !== selectedHeatmapView) return;
     if (!overviewTrend.snapshot || !appTrend.snapshot) return;
 
@@ -605,14 +688,10 @@ export default function Data({
           initialDimension={overviewTrendChart.initialDimension}
           canOpenHistory={canOpenTrendHistory}
           onSelectionChange={setSelectedTrendRange}
-          onMouseDownCapture={(event) => {
-            preventChartTextSelection(event, canOpenTrendHistory);
-          }}
+          onMouseDownCapture={handleTrendMouseDownCapture}
           onDoubleClickCapture={handleTrendDoubleClickCapture}
           onMouseMove={handleTrendMouseMove}
-          onMouseLeave={() => {
-            activeTrendDateRef.current = null;
-          }}
+          onMouseLeave={handleTrendMouseLeave}
         />
 
         <DataHeatmapPanel

--- a/src/features/data/components/DataAppTrendPanel.tsx
+++ b/src/features/data/components/DataAppTrendPanel.tsx
@@ -1,0 +1,269 @@
+import { memo, type MouseEvent, type RefObject } from "react";
+import { Search } from "lucide-react";
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, XAxis, YAxis } from "recharts";
+import { UI_TEXT } from "../../../shared/copy/index.ts";
+import QuietChartTooltip from "../../../shared/components/QuietChartTooltip";
+import {
+  formatChartHours,
+  formatDuration,
+} from "../../history/services/historyFormatting";
+import type { DataTrendRangeSelection } from "../services/dataTrendRange.ts";
+import type { DataAppOption, DataAppTrendPoint, DataAppTrendViewModel } from "../services/dataReadModel.ts";
+import DataTrendRangeControl from "./DataTrendRangeControl.tsx";
+
+const DATA_TREND_X_AXIS_MIN_TICK_GAP = 24;
+
+interface DataChartDimension {
+  width: number;
+  height: number;
+}
+
+interface DataAppTrendPanelProps {
+  selection: DataTrendRangeSelection;
+  viewModel: DataAppTrendViewModel | null;
+  selectedApp: DataAppOption | null | undefined;
+  filteredAppOptions: DataAppOption[];
+  appSearchQuery: string;
+  hasAppSearchQuery: boolean;
+  chartData: DataAppTrendPoint[];
+  chartAxis: DataAppTrendViewModel["chartAxis"];
+  peakDay: DataAppTrendViewModel["peakDay"];
+  dataIcons: Record<string, string>;
+  appListRef: RefObject<HTMLDivElement | null>;
+  chartRef: RefObject<HTMLDivElement | null>;
+  initialDimension: DataChartDimension;
+  canOpenHistory: boolean;
+  onSelectionChange: (selection: DataTrendRangeSelection) => void;
+  onSearchQueryChange: (nextQuery: string) => void;
+  onAppSelect: (appKey: string) => void;
+  onMouseDownCapture: (event: MouseEvent<HTMLDivElement>) => void;
+  onDoubleClickCapture: (event: MouseEvent<HTMLDivElement>) => void;
+  onMouseMove: (event: unknown) => void;
+  onMouseLeave: () => void;
+}
+
+function getAppInitial(appName: string) {
+  const trimmed = appName.trim();
+  return trimmed ? trimmed.charAt(0).toUpperCase() : "?";
+}
+
+function DataAppTrendPanel({
+  selection,
+  viewModel,
+  selectedApp,
+  filteredAppOptions,
+  appSearchQuery,
+  hasAppSearchQuery,
+  chartData,
+  chartAxis,
+  peakDay,
+  dataIcons,
+  appListRef,
+  chartRef,
+  initialDimension,
+  canOpenHistory,
+  onSelectionChange,
+  onSearchQueryChange,
+  onAppSelect,
+  onMouseDownCapture,
+  onDoubleClickCapture,
+  onMouseMove,
+  onMouseLeave,
+}: DataAppTrendPanelProps) {
+  return (
+    <div className="qp-panel p-5 data-app-panel">
+      <div className="data-app-panel-header">
+        <div>
+          <h3 className="font-semibold text-[var(--qp-text-primary)] text-sm">
+            {UI_TEXT.data.appTrend}
+          </h3>
+        </div>
+        <div className="data-app-header-actions">
+          <div className={`data-app-selected-status ${selectedApp ? "" : "data-app-selected-status-empty"}`}>
+            {selectedApp && dataIcons[selectedApp.exeName] ? (
+              <img
+                src={dataIcons[selectedApp.exeName]}
+                alt=""
+                draggable={false}
+              />
+            ) : selectedApp ? (
+              getAppInitial(selectedApp.appName)
+            ) : (
+              ""
+            )}
+          </div>
+          <DataTrendRangeControl
+            ariaLabel={UI_TEXT.accessibility.data.appTrendRange}
+            selection={selection}
+            onChange={onSelectionChange}
+          />
+        </div>
+      </div>
+
+      {!viewModel ? (
+        <div className="data-app-grid invisible pointer-events-none select-none" aria-hidden="true">
+          <div className="data-app-sidebar">
+            <div className="data-app-search" />
+            <div className="data-app-list data-app-trend-list" />
+          </div>
+          <div className="data-app-chart-column">
+            <div className="data-app-metric-strip">
+              <div className="data-app-metric">
+                <span>-</span>
+                <strong>-</strong>
+              </div>
+              <div className="data-app-metric">
+                <span>-</span>
+                <strong>-</strong>
+              </div>
+              <div className="data-app-metric">
+                <span>-</span>
+                <strong>-</strong>
+              </div>
+              <div className="data-app-metric">
+                <span>-</span>
+                <strong>-</strong>
+              </div>
+            </div>
+            <div
+              ref={chartRef}
+              className="data-app-chart data-chart-placeholder"
+            />
+          </div>
+        </div>
+      ) : viewModel.appOptions.length === 0 ? (
+        <div className="data-app-loading text-[var(--qp-text-tertiary)] text-xs">
+          {UI_TEXT.data.appTrendEmpty}
+        </div>
+      ) : (
+        <div className="data-app-grid">
+          <div className="data-app-sidebar">
+            <label className="data-app-search">
+              <Search size={14} aria-hidden />
+              <input
+                value={appSearchQuery}
+                onChange={(event) => onSearchQueryChange(event.target.value)}
+                placeholder={UI_TEXT.data.appSearchPlaceholder}
+                aria-label={UI_TEXT.data.appSearchPlaceholder}
+              />
+            </label>
+            <div
+              key={hasAppSearchQuery ? "searching" : "all"}
+              ref={appListRef}
+              className="data-app-list data-app-trend-list"
+              aria-label={UI_TEXT.data.appTrendAppList}
+            >
+              {filteredAppOptions.length === 0 ? (
+                <div className="data-app-empty text-[var(--qp-text-tertiary)] text-xs">
+                  {UI_TEXT.data.appTrendNoMatch}
+                </div>
+              ) : filteredAppOptions.map((app) => {
+                const isSelected = selectedApp?.appKey === app.appKey;
+                return (
+                  <button
+                    key={app.appKey}
+                    type="button"
+                    className={`data-app-option ${isSelected ? "data-app-option-selected" : ""}`}
+                    onClick={() => onAppSelect(app.appKey)}
+                    aria-pressed={isSelected}
+                  >
+                    <span className="data-app-option-icon" aria-hidden>
+                      {dataIcons[app.exeName] ? (
+                        <img src={dataIcons[app.exeName]} alt="" draggable={false} />
+                      ) : (
+                        getAppInitial(app.appName)
+                      )}
+                    </span>
+                    <span className="data-app-option-main">
+                      <span className="data-app-option-name">{app.appName}</span>
+                      <span className="data-app-option-meta">{Math.round(app.percentage)}% · {app.exeName}</span>
+                    </span>
+                    <span className="data-app-option-duration">
+                      {formatDuration(app.totalDuration)}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="data-app-chart-column">
+            <div className="data-app-metric-strip">
+              <div className="data-app-metric">
+                <span>{UI_TEXT.data.appTrendTotal}</span>
+                <strong>{formatDuration(selectedApp?.totalDuration ?? 0)}</strong>
+              </div>
+              <div className="data-app-metric">
+                <span>{viewModel.granularity === "month" ? UI_TEXT.data.monthlyAverage : UI_TEXT.data.appTrendAverage}</span>
+                <strong>{formatDuration(selectedApp?.averageDuration ?? 0)}</strong>
+              </div>
+              <div className="data-app-metric">
+                <span>{UI_TEXT.data.appTrendActiveDays}</span>
+                <strong>{selectedApp?.activeDayCount ?? 0}</strong>
+              </div>
+              <div className="data-app-metric">
+                <span>{UI_TEXT.data.appTrendPeakDay}</span>
+                <strong>{peakDay ? formatDuration(peakDay.duration) : "-"}</strong>
+              </div>
+            </div>
+            <div
+              ref={chartRef}
+              className={`data-app-chart ${canOpenHistory ? "data-chart-openable" : ""}`}
+              onMouseDownCapture={onMouseDownCapture}
+              onDoubleClickCapture={onDoubleClickCapture}
+            >
+              <ResponsiveContainer
+                width="100%"
+                height="100%"
+                initialDimension={initialDimension}
+              >
+                <AreaChart
+                  data={chartData}
+                  margin={{ top: 10, right: 18, left: -20, bottom: 0 }}
+                  onMouseMove={onMouseMove}
+                  onMouseLeave={onMouseLeave}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--qp-border-subtle)" strokeOpacity={0.58} />
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fontSize: 10, fill: "var(--qp-text-tertiary)" }}
+                    axisLine={false}
+                    tickLine={false}
+                    interval="preserveStartEnd"
+                    minTickGap={DATA_TREND_X_AXIS_MIN_TICK_GAP}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 10, fill: "var(--qp-text-tertiary)" }}
+                    axisLine={false}
+                    tickLine={false}
+                    ticks={chartAxis.ticks}
+                    domain={[0, chartAxis.domainMax]}
+                    tickFormatter={(value) => formatChartHours(Number(value))}
+                  />
+                  <QuietChartTooltip
+                    formatter={(value) => [
+                      formatDuration(Number(value) * 3600000),
+                      UI_TEXT.data.appTrendUsage,
+                    ]}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="hours"
+                    stroke="var(--qp-accent-default)"
+                    strokeWidth={2}
+                    fill="var(--qp-accent-default)"
+                    fillOpacity={0.1}
+                    dot={{ fill: "var(--qp-accent-default)", r: 2.5 }}
+                    isAnimationActive={false}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default memo(DataAppTrendPanel);

--- a/src/features/data/components/DataHeatmapPanel.tsx
+++ b/src/features/data/components/DataHeatmapPanel.tsx
@@ -1,10 +1,14 @@
-import { type CSSProperties, useMemo } from "react";
+import {
+  type CSSProperties,
+  useMemo,
+  useRef,
+} from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { UI_TEXT } from "../../../shared/copy/index.ts";
 import QuietSegmentedFilter from "../../../shared/components/QuietSegmentedFilter";
-import QuietTooltip from "../../../shared/components/QuietTooltip";
 import { formatDuration } from "../../history/services/historyFormatting";
 import type { HeatmapSelection, HeatmapWeek } from "../services/dataReadModel.ts";
+import DataHeatmapTooltip from "./DataHeatmapTooltip.tsx";
 
 export type HeatmapGranularity = "daily" | "weekly";
 
@@ -79,6 +83,7 @@ export default function DataHeatmapPanel({
   onSelectAdjacentHeatmapView,
   onOpenHistoryDate,
 }: DataHeatmapPanelProps) {
+  const heatmapWeeksRef = useRef<HTMLDivElement | null>(null);
   const weeklyHeatmapCells = useMemo(() => buildWeeklyHeatmapCells(rows), [rows]);
   const weeklyHeatmapCellsByKey = useMemo(
     () => new Map(weeklyHeatmapCells.map((cell) => [cell.key, cell])),
@@ -149,7 +154,10 @@ export default function DataHeatmapPanel({
                   <span key={`${weekday}-${index}`}>{weekday}</span>
                 ))}
               </div>
-              <div className="data-heatmap-weeks">
+              <div
+                ref={heatmapWeeksRef}
+                className="data-heatmap-weeks"
+              >
                 {rows.map((week) => {
                   const weeklyCell = weeklyHeatmapCellsByKey.get(week.key);
                   return (
@@ -180,30 +188,22 @@ export default function DataHeatmapPanel({
                           ? isWeeklyFilledCell ? weeklyCell?.intensity ?? 0 : 0
                           : cell.intensity;
                         return (
-                          <QuietTooltip
+                          <span
                             key={`${selectedHeatmapViewKey}:${cell.key}`}
-                            label={tooltipLabel}
-                            placement="top"
-                            disabled={tooltipDisabled}
-                            className={`data-heatmap-tooltip-anchor ${
-                              tooltipDisabled ? "data-heatmap-tooltip-anchor-unavailable" : ""
-                            }`}
-                          >
-                            <span
-                              className={`data-heatmap-cell ${
-                                canOpenHistoryDate ? "data-heatmap-cell-openable" : ""
-                              } ${
-                                isDailyFutureCell || isWeeklyFutureCell ? "data-heatmap-cell-future" : ""
-                              } ${cell.isOutsideYear ? "data-heatmap-cell-outside" : ""}`}
-                              onDoubleClick={() => {
-                                if (canOpenHistoryDate) {
-                                  onOpenHistoryDate?.(cell.date);
-                                }
-                              }}
-                              data-history-date={canOpenHistoryDate ? cell.date : undefined}
-                              style={{ "--heatmap-intensity": heatmapIntensity } as CSSProperties}
-                            />
-                          </QuietTooltip>
+                            className={`data-heatmap-cell ${
+                              canOpenHistoryDate ? "data-heatmap-cell-openable" : ""
+                            } ${
+                              isDailyFutureCell || isWeeklyFutureCell ? "data-heatmap-cell-future" : ""
+                            } ${cell.isOutsideYear ? "data-heatmap-cell-outside" : ""}`}
+                            onDoubleClick={() => {
+                              if (canOpenHistoryDate) {
+                                onOpenHistoryDate?.(cell.date);
+                              }
+                            }}
+                            data-heatmap-tooltip={tooltipDisabled ? undefined : tooltipLabel}
+                            data-history-date={canOpenHistoryDate ? cell.date : undefined}
+                            style={{ "--heatmap-intensity": heatmapIntensity } as CSSProperties}
+                          />
                         );
                       })}
                     </div>
@@ -214,6 +214,12 @@ export default function DataHeatmapPanel({
           </div>
         </div>
       </div>
+      <DataHeatmapTooltip
+        containerRef={heatmapWeeksRef}
+        granularity={granularity}
+        rows={rows}
+        selectedHeatmapViewKey={selectedHeatmapViewKey}
+      />
     </div>
   );
 }

--- a/src/features/data/components/DataHeatmapPanel.tsx
+++ b/src/features/data/components/DataHeatmapPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   type CSSProperties,
   useMemo,
   useRef,
@@ -70,7 +71,7 @@ function buildWeeklyHeatmapCells(rows: HeatmapWeek[]) {
   }));
 }
 
-export default function DataHeatmapPanel({
+function DataHeatmapPanel({
   selectedHeatmapView,
   selectedHeatmapViewKey,
   selectedHeatmapViewLabel,
@@ -223,3 +224,5 @@ export default function DataHeatmapPanel({
     </div>
   );
 }
+
+export default memo(DataHeatmapPanel);

--- a/src/features/data/components/DataHeatmapTooltip.tsx
+++ b/src/features/data/components/DataHeatmapTooltip.tsx
@@ -1,0 +1,195 @@
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+interface HeatmapTooltipState {
+  label: string;
+}
+
+interface HeatmapTooltipPosition {
+  top: number;
+  left: number;
+}
+
+interface DataHeatmapTooltipProps {
+  containerRef: RefObject<HTMLDivElement | null>;
+  granularity: string;
+  rows: readonly unknown[];
+  selectedHeatmapViewKey: string;
+}
+
+const HEATMAP_TOOLTIP_GAP = 8;
+const HEATMAP_TOOLTIP_VIEWPORT_PADDING = 8;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function resolveHeatmapTooltipPosition(
+  anchorRect: DOMRect,
+  tooltipWidth: number,
+  tooltipHeight: number,
+): HeatmapTooltipPosition {
+  const availableTop = anchorRect.top;
+  const availableBottom = window.innerHeight - anchorRect.bottom;
+  const useBottom = availableTop < tooltipHeight + HEATMAP_TOOLTIP_GAP && availableBottom > availableTop;
+  const top = useBottom
+    ? anchorRect.bottom + HEATMAP_TOOLTIP_GAP
+    : anchorRect.top - tooltipHeight - HEATMAP_TOOLTIP_GAP;
+  const left = anchorRect.left + (anchorRect.width - tooltipWidth) / 2;
+
+  return {
+    top: clamp(
+      top,
+      HEATMAP_TOOLTIP_VIEWPORT_PADDING,
+      window.innerHeight - tooltipHeight - HEATMAP_TOOLTIP_VIEWPORT_PADDING,
+    ),
+    left: clamp(
+      left,
+      HEATMAP_TOOLTIP_VIEWPORT_PADDING,
+      window.innerWidth - tooltipWidth - HEATMAP_TOOLTIP_VIEWPORT_PADDING,
+    ),
+  };
+}
+
+function findHeatmapTooltipAnchor(target: EventTarget | null, container: HTMLElement) {
+  if (!(target instanceof Element)) return null;
+
+  const anchor = target.closest<HTMLElement>("[data-heatmap-tooltip]");
+  return anchor && container.contains(anchor) ? anchor : null;
+}
+
+export default function DataHeatmapTooltip({
+  containerRef,
+  granularity,
+  rows,
+  selectedHeatmapViewKey,
+}: DataHeatmapTooltipProps) {
+  const activeTooltipAnchorRef = useRef<HTMLElement | null>(null);
+  const activeTooltipLabelRef = useRef<string | null>(null);
+  const heatmapTooltipRef = useRef<HTMLDivElement | null>(null);
+  const [heatmapTooltip, setHeatmapTooltip] = useState<HeatmapTooltipState | null>(null);
+  const [heatmapTooltipPosition, setHeatmapTooltipPosition] = useState<HeatmapTooltipPosition | null>(null);
+
+  const hideTooltip = useCallback(() => {
+    activeTooltipAnchorRef.current = null;
+    activeTooltipLabelRef.current = null;
+    setHeatmapTooltip(null);
+    setHeatmapTooltipPosition(null);
+  }, []);
+  const updateTooltipPosition = useCallback(() => {
+    const anchor = activeTooltipAnchorRef.current;
+    const tooltip = heatmapTooltipRef.current;
+    if (!anchor || !tooltip) {
+      return;
+    }
+
+    const anchorRect = anchor.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    setHeatmapTooltipPosition(resolveHeatmapTooltipPosition(
+      anchorRect,
+      tooltipRect.width,
+      tooltipRect.height,
+    ));
+  }, []);
+  const showTooltip = useCallback((event: PointerEvent) => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const anchor = findHeatmapTooltipAnchor(event.target, container);
+    if (!anchor) {
+      return;
+    }
+
+    const label = anchor.dataset.heatmapTooltip;
+    if (!label) {
+      return;
+    }
+
+    if (activeTooltipAnchorRef.current === anchor && activeTooltipLabelRef.current === label) {
+      return;
+    }
+
+    activeTooltipAnchorRef.current = anchor;
+    activeTooltipLabelRef.current = label;
+    setHeatmapTooltip({ label });
+    setHeatmapTooltipPosition(null);
+  }, [containerRef]);
+  const hideTooltipAfterPointerOut = useCallback((event: PointerEvent) => {
+    const container = containerRef.current;
+    if (container && findHeatmapTooltipAnchor(event.relatedTarget, container)) {
+      return;
+    }
+
+    hideTooltip();
+  }, [containerRef, hideTooltip]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    container.addEventListener("pointerover", showTooltip);
+    container.addEventListener("pointerout", hideTooltipAfterPointerOut);
+    container.addEventListener("pointerdown", hideTooltip, true);
+    container.addEventListener("pointerleave", hideTooltip);
+    return () => {
+      container.removeEventListener("pointerover", showTooltip);
+      container.removeEventListener("pointerout", hideTooltipAfterPointerOut);
+      container.removeEventListener("pointerdown", hideTooltip, true);
+      container.removeEventListener("pointerleave", hideTooltip);
+    };
+  }, [containerRef, hideTooltip, hideTooltipAfterPointerOut, showTooltip]);
+
+  useLayoutEffect(() => {
+    if (!heatmapTooltip) {
+      return undefined;
+    }
+
+    updateTooltipPosition();
+    return undefined;
+  }, [heatmapTooltip, updateTooltipPosition]);
+
+  useEffect(() => {
+    if (!heatmapTooltip) {
+      return undefined;
+    }
+
+    const handleViewportChange = () => updateTooltipPosition();
+    window.addEventListener("resize", handleViewportChange);
+    window.addEventListener("scroll", handleViewportChange, true);
+    return () => {
+      window.removeEventListener("resize", handleViewportChange);
+      window.removeEventListener("scroll", handleViewportChange, true);
+    };
+  }, [heatmapTooltip, updateTooltipPosition]);
+
+  useEffect(() => {
+    hideTooltip();
+  }, [granularity, hideTooltip, rows, selectedHeatmapViewKey]);
+
+  return heatmapTooltip && typeof document !== "undefined" && createPortal(
+    <div
+      ref={heatmapTooltipRef}
+      role="tooltip"
+      className="qp-tooltip"
+      style={{
+        top: heatmapTooltipPosition ? `${heatmapTooltipPosition.top}px` : 0,
+        left: heatmapTooltipPosition ? `${heatmapTooltipPosition.left}px` : 0,
+        visibility: heatmapTooltipPosition ? "visible" : "hidden",
+      }}
+    >
+      {heatmapTooltip.label}
+    </div>,
+    document.body,
+  );
+}

--- a/src/features/data/components/DataTrendPanel.tsx
+++ b/src/features/data/components/DataTrendPanel.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent, RefObject } from "react";
+import { memo, type MouseEvent, type RefObject } from "react";
 import { CalendarDays, Clock3 } from "lucide-react";
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, XAxis, YAxis } from "recharts";
 import { UI_TEXT } from "../../../shared/copy/index.ts";
@@ -31,7 +31,7 @@ interface DataTrendPanelProps {
   onMouseLeave: () => void;
 }
 
-export default function DataTrendPanel({
+function DataTrendPanel({
   selection,
   viewModel,
   chartRef,
@@ -133,3 +133,5 @@ export default function DataTrendPanel({
     </div>
   );
 }
+
+export default memo(DataTrendPanel);

--- a/src/features/data/hooks/useDataTrendSnapshot.ts
+++ b/src/features/data/hooks/useDataTrendSnapshot.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { startTransition, useEffect, useMemo, useState } from "react";
 import {
   getCachedDataTrendSnapshot,
   type DataTrendSnapshot,
@@ -17,6 +17,19 @@ interface UseDataTrendSnapshotParams {
   refreshKey: number;
   loadSnapshot: (selection: DataTrendRangeSelection, nowMs?: number) => Promise<DataTrendSnapshot>;
   deferCachedRefresh?: boolean;
+}
+
+function areDataTrendSnapshotsEquivalent(
+  left: DataTrendSnapshot | null,
+  right: DataTrendSnapshot,
+): boolean {
+  return Boolean(
+    left
+    && left.fetchedAtMs === right.fetchedAtMs
+    && left.range.cacheKey === right.range.cacheKey
+    && left.sessions === right.sessions
+    && left.icons === right.icons,
+  );
 }
 
 export function useDataTrendSnapshot({
@@ -39,8 +52,10 @@ export function useDataTrendSnapshot({
     const nextRange = resolveDataTrendRange(selection, nextNowMs);
     const nextCached = getCachedDataTrendSnapshot(nextRange);
     if (nextCached) {
-      setSnapshot(nextCached);
-      setNowMs(nextCached.fetchedAtMs);
+      setSnapshot((current) => (
+        areDataTrendSnapshotsEquivalent(current, nextCached) ? current : nextCached
+      ));
+      setNowMs((current) => current === nextCached.fetchedAtMs ? current : nextCached.fetchedAtMs);
       setHasFetchedOnce(true);
       setLoading(false);
     } else {
@@ -50,9 +65,11 @@ export function useDataTrendSnapshot({
     const loadFreshSnapshot = () => {
       void loadSnapshot(selection, nextNowMs).then((nextSnapshot) => {
         if (cancelled) return;
-        setSnapshot(nextSnapshot);
-        setNowMs(nextSnapshot.fetchedAtMs);
-        setHasFetchedOnce(true);
+        startTransition(() => {
+          setSnapshot(nextSnapshot);
+          setNowMs(nextSnapshot.fetchedAtMs);
+          setHasFetchedOnce(true);
+        });
       }).finally(() => {
         if (!cancelled) setLoading(false);
       });

--- a/src/features/data/services/dataAppSearch.ts
+++ b/src/features/data/services/dataAppSearch.ts
@@ -1,0 +1,71 @@
+import type { DataAppOption } from "./dataReadModel.ts";
+
+function getDataAppOptionDisplayKey(app: DataAppOption) {
+  return `${app.appName.trim().toLowerCase().replace(/\s+/g, " ")}|${app.exeName.trim().toLowerCase()}`;
+}
+
+export function dedupeDataAppOptions(options: DataAppOption[]) {
+  const merged = new Map<string, DataAppOption>();
+
+  for (const app of options) {
+    const key = getDataAppOptionDisplayKey(app);
+    const existing = merged.get(key);
+
+    if (!existing) {
+      merged.set(key, { ...app });
+      continue;
+    }
+
+    existing.totalDuration += app.totalDuration;
+    existing.percentage += app.percentage;
+    existing.averageDuration += app.averageDuration;
+    existing.activeDayCount = Math.max(existing.activeDayCount, app.activeDayCount);
+  }
+
+  return Array.from(merged.values()).sort((left, right) => right.totalDuration - left.totalDuration);
+}
+
+export function filterDataAppOptionsForQuery(options: DataAppOption[], query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return options;
+
+  return options.filter((app) => (
+    app.appName.toLowerCase().includes(normalizedQuery)
+    || app.exeName.toLowerCase().includes(normalizedQuery)
+  ));
+}
+
+interface ResolveDataAppSearchSelectionArgs {
+  wasSearching: boolean;
+  isSearching: boolean;
+  selectedAppKey: string | null;
+  selectedApp: DataAppOption | null | undefined;
+  filteredOptions: DataAppOption[];
+}
+
+export function resolveDataAppSearchSelection({
+  wasSearching,
+  isSearching,
+  selectedAppKey,
+  selectedApp,
+  filteredOptions,
+}: ResolveDataAppSearchSelectionArgs): string | null | undefined {
+  if (wasSearching && !isSearching) {
+    return null;
+  }
+
+  if (!isSearching) {
+    return undefined;
+  }
+
+  const selectedKey = selectedApp?.appKey ?? selectedAppKey;
+  const selectedAppKeyIsVisible = Boolean(
+    selectedKey && filteredOptions.some((app) => app.appKey === selectedKey),
+  );
+
+  if (selectedAppKeyIsVisible) {
+    return undefined;
+  }
+
+  return filteredOptions[0]?.appKey;
+}

--- a/src/styles/quiet-pro.css
+++ b/src/styles/quiet-pro.css
@@ -1299,12 +1299,6 @@
   );
 }
 
-.data-heatmap-tooltip-anchor.qp-tooltip-anchor {
-  display: block;
-  height: var(--data-heatmap-cell-size);
-  width: var(--data-heatmap-cell-size);
-}
-
 .data-heatmap-cell {
   display: block;
   height: var(--data-heatmap-cell-size);
@@ -1330,10 +1324,6 @@
 .data-heatmap-cell-outside {
   border-color: transparent;
   background: transparent;
-}
-
-.data-heatmap-tooltip-anchor-unavailable.qp-tooltip-anchor {
-  pointer-events: none;
 }
 
 .data-heatmap-loading-state .data-heatmap-cell,

--- a/tests/dataAppSearch.test.ts
+++ b/tests/dataAppSearch.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import {
+  dedupeDataAppOptions,
+  filterDataAppOptionsForQuery,
+  resolveDataAppSearchSelection,
+} from "../src/features/data/services/dataAppSearch.ts";
+import type { DataAppOption } from "../src/features/data/services/dataReadModel.ts";
+
+let passed = 0;
+
+function runTest(name: string, fn: () => void) {
+  fn();
+  passed += 1;
+  console.log(`PASS ${name}`);
+}
+
+function makeAppOption(overrides: Partial<DataAppOption>): DataAppOption {
+  return {
+    appKey: "cursor.exe",
+    appName: "Cursor",
+    exeName: "cursor.exe",
+    totalDuration: 60_000,
+    percentage: 10,
+    averageDuration: 30_000,
+    activeDayCount: 1,
+    ...overrides,
+  };
+}
+
+runTest("dedupeDataAppOptions merges duplicate display options", () => {
+  const rows = dedupeDataAppOptions([
+    makeAppOption({
+      appKey: "antigravity.exe",
+      appName: "Antigravity",
+      exeName: "antigravity.exe",
+      totalDuration: 20_000,
+      percentage: 5,
+      averageDuration: 10_000,
+      activeDayCount: 1,
+    }),
+    makeAppOption({
+      appKey: "Antigravity.exe",
+      appName: " Antigravity ",
+      exeName: "Antigravity.exe",
+      totalDuration: 30_000,
+      percentage: 6,
+      averageDuration: 15_000,
+      activeDayCount: 3,
+    }),
+  ]);
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].totalDuration, 50_000);
+  assert.equal(rows[0].percentage, 11);
+  assert.equal(rows[0].averageDuration, 25_000);
+  assert.equal(rows[0].activeDayCount, 3);
+});
+
+runTest("filterDataAppOptionsForQuery returns deduped options for empty query", () => {
+  const options = [
+    makeAppOption({ appKey: "cursor.exe", totalDuration: 20_000 }),
+    makeAppOption({ appKey: "blender.exe", appName: "Blender", exeName: "blender.exe", totalDuration: 10_000 }),
+  ];
+
+  assert.equal(filterDataAppOptionsForQuery(options, "   "), options);
+});
+
+runTest("filterDataAppOptionsForQuery matches app name and executable", () => {
+  const options = [
+    makeAppOption({ appKey: "cursor.exe", appName: "Cursor", exeName: "cursor.exe" }),
+    makeAppOption({ appKey: "blender.exe", appName: "Blender", exeName: "blender.exe" }),
+  ];
+
+  assert.deepEqual(
+    filterDataAppOptionsForQuery(options, "blend").map((app) => app.appKey),
+    ["blender.exe"],
+  );
+  assert.deepEqual(
+    filterDataAppOptionsForQuery(options, "cursor.exe").map((app) => app.appKey),
+    ["cursor.exe"],
+  );
+});
+
+runTest("resolveDataAppSearchSelection selects first match when selected app is hidden", () => {
+  const filteredOptions = [
+    makeAppOption({ appKey: "blender.exe", appName: "Blender", exeName: "blender.exe" }),
+  ];
+
+  assert.equal(resolveDataAppSearchSelection({
+    wasSearching: false,
+    isSearching: true,
+    selectedAppKey: "cursor.exe",
+    selectedApp: makeAppOption({ appKey: "cursor.exe" }),
+    filteredOptions,
+  }), "blender.exe");
+});
+
+runTest("resolveDataAppSearchSelection clears explicit selection when search is cleared", () => {
+  assert.equal(resolveDataAppSearchSelection({
+    wasSearching: true,
+    isSearching: false,
+    selectedAppKey: "cursor.exe",
+    selectedApp: makeAppOption({ appKey: "cursor.exe" }),
+    filteredOptions: [],
+  }), null);
+});
+
+console.log(`Passed ${passed} data app search tests`);

--- a/tests/uiBrowserSmoke/dataScenarios.ts
+++ b/tests/uiBrowserSmoke/dataScenarios.ts
@@ -236,6 +236,80 @@ export async function runDataScenarios(context: BrowserSmokeContext) {
     await waitForExpression(client!, sessionId, `document.querySelectorAll(".data-trend-range-trigger")[1]?.textContent?.trim() === "1天"`);
   });
 
+  await runTest("data heatmap shows one delegated tooltip on hover", async () => {
+    await client!.command("Emulation.setDeviceMetricsOverride", {
+      width: 1280,
+      height: 820,
+      deviceScaleFactor: 1,
+      mobile: false,
+    }, sessionId);
+    const openedData = await evaluate(client!, sessionId, `
+      (() => {
+        const node = document.querySelector('[aria-label=' + ${jsonString(JSON.stringify("数据"))} + ']');
+        if (!node) return false;
+        node.click();
+        return true;
+      })()
+    `);
+    assert.equal(openedData, true);
+    await waitForExpression(
+      client!,
+      sessionId,
+      `document.querySelector('[aria-label=' + ${jsonString(JSON.stringify("数据"))} + ']')?.className.includes("qp-nav-item-active")`,
+    );
+    const yesterdayKey = await evaluate(client!, sessionId, `
+      (() => {
+        const date = new Date();
+        date.setDate(date.getDate() - 1);
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, "0");
+        const day = String(date.getDate()).padStart(2, "0");
+        return year + "-" + month + "-" + day;
+      })()
+    `) as string;
+    await waitForExpression(
+      client!,
+      sessionId,
+      `Boolean(document.querySelector('[data-history-date=' + ${jsonString(JSON.stringify(yesterdayKey))} + '][data-heatmap-tooltip]'))`,
+      45_000,
+    );
+    const tooltipLabel = await evaluate(client!, sessionId, `
+      (() => {
+        const cell = document.querySelector('[data-history-date=' + ${jsonString(JSON.stringify(yesterdayKey))} + '][data-heatmap-tooltip]');
+        if (!cell) return "";
+        const label = cell.getAttribute("data-heatmap-tooltip") ?? "";
+        cell.dispatchEvent(new PointerEvent("pointerover", {
+          bubbles: true,
+          cancelable: true,
+          pointerType: "mouse",
+        }));
+        return label;
+      })()
+    `) as string;
+    assert.ok(tooltipLabel);
+    await waitForExpression(
+      client!,
+      sessionId,
+      `document.querySelectorAll('.qp-tooltip[role="tooltip"]').length === 1 && document.querySelector('.qp-tooltip[role="tooltip"]')?.textContent === ${jsonString(tooltipLabel)}`,
+    );
+    await evaluate(client!, sessionId, `
+      (() => {
+        const cell = document.querySelector('[data-history-date=' + ${jsonString(JSON.stringify(yesterdayKey))} + '][data-heatmap-tooltip]');
+        cell?.dispatchEvent(new PointerEvent("pointerout", {
+          bubbles: true,
+          cancelable: true,
+          pointerType: "mouse",
+          relatedTarget: document.body,
+        }));
+      })()
+    `);
+    await waitForExpression(
+      client!,
+      sessionId,
+      `document.querySelectorAll('.qp-tooltip[role="tooltip"]').length === 0`,
+    );
+  });
+
   await runTest("data heatmap opens the selected day in history", async () => {
     await client!.command("Emulation.setDeviceMetricsOverride", {
       width: 1280,

--- a/tests/uiSmoke.test.ts
+++ b/tests/uiSmoke.test.ts
@@ -347,6 +347,10 @@ await runTest("Data regular view avoids visible loading and skeleton branches", 
   assert.doesNotMatch(heatmapPanel, /QuietTooltip/);
   assert.match(heatmapPanel, /data-heatmap-tooltip/);
   assert.match(data, /selectedHeatmapView === "recent"/);
+  assert.match(data, /freshReadModelsReady/);
+  assert.match(data, /shouldDeferRuntimeReadModels/);
+  assert.match(data, /shouldDeferHeatmapRows/);
+  assert.match(data, /EMPTY_DATA_APP_TREND_POINTS/);
 });
 
 await runTest("History regular view avoids visible loading copy", () => {

--- a/tests/uiSmoke.test.ts
+++ b/tests/uiSmoke.test.ts
@@ -344,6 +344,8 @@ await runTest("Data regular view avoids visible loading and skeleton branches", 
   assert.match(heatmapPanel, /hideRecentDailyFutureCell/);
   assert.match(heatmapPanel, /isDailyFutureCell/);
   assert.match(heatmapPanel, /isWeeklyFutureCell/);
+  assert.doesNotMatch(heatmapPanel, /QuietTooltip/);
+  assert.match(heatmapPanel, /data-heatmap-tooltip/);
   assert.match(data, /selectedHeatmapView === "recent"/);
 });
 


### PR DESCRIPTION
## Purpose

针对 #28 讨论里提到的部分页面卡顿问题，此 PR 仅做一批低风险前端壳层优化，单独从组件拆分、搜索计算缓存、减少图表重复渲染这些方向处理 Data 页。

Refs https://github.com/Ceceliaee/patina/pull/28#issuecomment-4815959904 ：
> 后面要优化 Data 页，会单独从计算、缓存、聚合、减少重复渲染这些方向做

## Changes

- 拆出 App Trend 面板，隔离图表渲染。
- 抽离 app 搜索逻辑，并缓存去重结果。
- Data 首屏优先使用 bootstrap/cache 内容，首帧后再刷新 fresh 读模型。
- 稳定 Data 页图表、列表和热力图子组件 props，减少无效重渲染。
- 将 heatmap tooltip 替换为 Data 页专用的委托式单浮层实现，保持视觉和用户语义不变，降低密集 cell 的渲染成本。
- 调整 Data trend snapshot hook，降低 cache/fresh 更新对首屏的抢占。
- 补充 app 搜索、Data 首屏性能防线，以及 heatmap delegated tooltip 的浏览器 smoke 测试。

## Scope

### Included

- Data 页 App Trend 面板拆分。
- Data 页 app 搜索计算优化。
- App Trend 图表渲染隔离。
- Data 首屏 bootstrap/cache 优先渲染。
- Data 页 fresh trend / heatmap 更新延后到首帧后。
- Data Trend / Heatmap 面板 memo 化。
- Heatmap tooltip 的 Data 页专用委托式实现，不改变 tooltip 的视觉样式或用户语义。
- app 搜索服务单测。
- Data 首屏 defer 逻辑 smoke 防线。
- Heatmap delegated tooltip browser smoke 防线。

### Not Included

- 不改动 Data 页视觉样式。
- 不新增 aggregate context 缓存。
- 不把 heatmap tooltip 实现上升为 shared 通用 tooltip 方案。
- 不处理 #28 里的 UI 动效问题。

## Risk Review

- Tracking correctness: N/A，未改追踪逻辑。
- Local data safety: N/A，未改本地数据读写、迁移、备份或清理。
- Privacy or security: N/A，未新增本地或网络接口。
- Compatibility and migration: N/A，无数据结构和迁移变化。
- Failure and recovery behavior: 低风险。主要是 UI 组件拆分、纯前端搜索规则抽离、首屏缓存优先渲染和 heatmap tooltip 渲染实现替换。失败面集中在 Data 页 App Trend 搜索/选中状态、首屏 cache/fresh 过渡，以及 heatmap hover tooltip；已补 focused tests 与 browser smoke 覆盖。

## Validation

- [x] `npm run check`
- [x] `npm run check:full` for Rust, tracking, SQLite, runtime, or architecture-boundary changes
- [x] `npm run release:check` for release, changelog, updater, version, tag, or packaging changes
- [x] Added or updated focused tests for the changed behavior

### Additional validation

UI响应：
```
平均：54.12ms -> 31.09ms
p95/max：225.80ms -> 33.40ms
```

内容基础渲染速度：
```
平均：418.23ms -> 327.25ms
p50：383.09ms -> 318.96ms
p95/max：618.90ms -> 398.83ms
```

## Screenshots

N/A，无可见 UI 变化。

## Contributor Checklist

- [x] I read the relevant active project documents under `docs/`.
- [x] This pull request solves one coherent problem and excludes unrelated cleanup.
- [x] New behavior is placed under the correct owner and does not bypass architecture boundaries.
- [x] I rebased onto the latest `main`, or confirmed that the branch is compatible with it.
- [x] I documented security behavior for any local or network interface.
- [x] I used `Refs #N` instead of an issue-closing keyword unless explicitly requested.