### PR TITLE
ui: 移除右侧主视图阴影切换动效

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { getUiText, setUiTextLanguage } from "../shared/copy/index.ts";
 import AppSidebar from "./components/AppSidebar";
 import AppTitleBar from "./components/AppTitleBar";
@@ -100,8 +100,6 @@ type HistoryDateRequest = {
   requestId: number;
 };
 
-const VIEW_ORDER: View[] = ["dashboard", "history", "data", "mapping", "tools", "settings", "about"];
-
 export default function AppShell() {
   return (
     <UpdateDialogProvider>
@@ -134,33 +132,6 @@ function AppShellContent() {
   const [historyDateRequest, setHistoryDateRequest] = useState<HistoryDateRequest | null>(null);
   const [toolsInitialTarget, setToolsInitialTarget] = useState<ToolsOpenTarget | null>(null);
   const [renderedView, setRenderedView] = useState<View>("dashboard");
-  const prevViewIndexRef = useRef(0);
-  const [viewTransitionStyle, setViewTransitionStyle] = useState<CSSProperties>({
-    "--qp-view-transition-offset": "12px",
-    "--qp-view-transition-duration": "220ms",
-  } as CSSProperties);
-
-  const changeRenderedView = useCallback((nextView: View) => {
-    const prevIndex = prevViewIndexRef.current;
-    const nextIndex = VIEW_ORDER.indexOf(nextView);
-
-    if (prevIndex !== nextIndex && nextIndex !== -1) {
-      const diff = nextIndex - prevIndex;
-      const direction = diff > 0 ? 1 : -1;
-      const absDiff = Math.abs(diff);
-      const offsetVal = 6 + Math.min(3, absDiff) * 4;
-      const durationVal = Math.max(170, 230 - absDiff * 15);
-
-      setViewTransitionStyle({
-        "--qp-view-transition-offset": `${direction * offsetVal}px`,
-        "--qp-view-transition-duration": `${durationVal}ms`,
-      } as CSSProperties);
-
-      prevViewIndexRef.current = nextIndex;
-    }
-
-    setRenderedView(nextView);
-  }, []);
 
   const renderedViewRequestRef = useRef(0);
   const warmupRuntimeReadyResolveRef = useRef<(() => void) | null>(null);
@@ -206,12 +177,12 @@ function AppShellContent() {
     const requestId = renderedViewRequestRef.current;
 
     if (!preloadableView) {
-      changeRenderedView(currentView);
+      setRenderedView(currentView);
       return undefined;
     }
 
     if (getPreloadableViewChunkStatus(preloadableView) === "resolved") {
-      changeRenderedView(currentView);
+      setRenderedView(currentView);
       return undefined;
     }
 
@@ -219,20 +190,20 @@ function AppShellContent() {
     void preloadLazyViewChunk(preloadableView)
       .then(() => {
         if (!cancelled && renderedViewRequestRef.current === requestId) {
-          changeRenderedView(currentView);
+          setRenderedView(currentView);
         }
       })
       .catch((error) => {
         console.warn(`Failed to preload ${preloadableView} view before navigation`, error);
         if (!cancelled && renderedViewRequestRef.current === requestId) {
-          changeRenderedView(currentView);
+          setRenderedView(currentView);
         }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [currentView, changeRenderedView]);
+  }, [currentView]);
 
   useAppThemeMode(
     settingsThemeModePreview ?? appSettings.themeMode,
@@ -519,8 +490,7 @@ function AppShellContent() {
           >
             <div
               key={renderedView}
-              style={viewTransitionStyle}
-              className="qp-view-container qp-motion-view-enter flex-1 min-h-0 flex flex-col h-full overflow-hidden"
+              className="qp-view-container flex-1 min-h-0 flex flex-col h-full overflow-hidden"
             >
               {renderedView === "dashboard" && (
                 <Dashboard

--- a/src/features/data/components/DataAppTrendPanel.tsx
+++ b/src/features/data/components/DataAppTrendPanel.tsx
@@ -138,7 +138,7 @@ function DataAppTrendPanel({
           {UI_TEXT.data.appTrendEmpty}
         </div>
       ) : (
-        <div className="data-app-grid qp-content-fade-in">
+        <div className="data-app-grid">
           <div className="data-app-sidebar">
             <label className="data-app-search">
               <Search size={14} aria-hidden />
@@ -210,7 +210,7 @@ function DataAppTrendPanel({
             </div>
             <div
               ref={chartRef}
-              className={`data-app-chart qp-content-fade-in ${canOpenHistory ? "data-chart-openable" : ""}`}
+              className={`data-app-chart ${canOpenHistory ? "data-chart-openable" : ""}`}
               onMouseDownCapture={onMouseDownCapture}
               onDoubleClickCapture={onDoubleClickCapture}
             >

--- a/src/features/data/components/DataHeatmapPanel.tsx
+++ b/src/features/data/components/DataHeatmapPanel.tsx
@@ -142,9 +142,7 @@ function DataHeatmapPanel({
       <div className="data-heatmap data-heatmap-calendar mt-5">
         <div className="data-heatmap-content">
           <div
-            className={`data-heatmap-scroll ${rows.length > 0 ? "qp-content-fade-in" : ""} ${
-              loading ? "data-heatmap-loading-state" : ""
-            }`}
+            className={loading ? "data-heatmap-scroll data-heatmap-loading-state" : "data-heatmap-scroll"}
             style={{ "--data-heatmap-week-count": rows.length } as CSSProperties}
           >
             <div className="data-heatmap-months" aria-hidden>

--- a/src/features/data/components/DataTrendPanel.tsx
+++ b/src/features/data/components/DataTrendPanel.tsx
@@ -72,7 +72,7 @@ function DataTrendPanel({
           ref={chartRef}
           className={`data-trend-chart ${
             viewModel
-              ? canOpenHistory ? "data-chart-openable qp-content-fade-in" : "qp-content-fade-in"
+              ? canOpenHistory ? "data-chart-openable" : ""
               : "data-chart-placeholder flex items-center justify-center text-[var(--qp-text-tertiary)] text-xs"
           }`}
           onMouseDownCapture={viewModel ? onMouseDownCapture : undefined}

--- a/src/shared/motion/quietMotion.ts
+++ b/src/shared/motion/quietMotion.ts
@@ -4,12 +4,12 @@ export function resolveQuietMotionMode(options: {
   enhancedMotionEnabled: boolean;
   prefersReducedMotion: boolean;
 }): QuietMotionMode {
-  if (options.enhancedMotionEnabled) {
-    return "enhanced";
-  }
-
   if (options.prefersReducedMotion) {
     return "reduced";
+  }
+
+  if (options.enhancedMotionEnabled) {
+    return "enhanced";
   }
 
   return "baseline";

--- a/src/styles/motion.css
+++ b/src/styles/motion.css
@@ -1,21 +1,15 @@
 :root {
-  --qp-motion-enhanced-view-duration: 220ms;
-  --qp-motion-enhanced-overlay-duration: 120ms;
-  --qp-motion-enhanced-nav-bg-duration: 180ms;
-  --qp-motion-enhanced-nav-indicator-duration: 250ms;
-  --qp-motion-enhanced-spring-ease: cubic-bezier(0.25, 1.25, 0.4, 1);
+  --qp-motion-enhanced-overlay-duration: 100ms;
+  --qp-motion-enhanced-nav-bg-duration: 260ms;
+  --qp-motion-enhanced-nav-indicator-duration: 320ms;
+  --qp-motion-enhanced-pane-duration: 150ms;
+  --qp-motion-enhanced-nav-bounce-ease: cubic-bezier(0.2, 1.28, 0.34, 1);
 }
 
-.qp-motion-view-enter,
 .qp-motion-overlay-enter,
 .qp-motion-popover-enter,
 .qp-toast-entry {
   animation: none;
-}
-
-[data-qp-motion="enhanced"] .qp-motion-view-enter {
-  will-change: transform, opacity;
-  animation: qp-view-fade-in var(--qp-view-transition-duration, var(--qp-motion-enhanced-view-duration)) var(--qp-motion-ease) both;
 }
 
 [data-qp-motion="enhanced"] .qp-motion-overlay-enter,
@@ -24,14 +18,10 @@
   animation: qp-motion-fade-in var(--qp-motion-enhanced-overlay-duration) var(--qp-motion-ease) both;
 }
 
-[data-qp-motion="enhanced"] .qp-content-fade-in {
-  animation: qp-content-fade-in var(--qp-motion-fast) var(--qp-motion-ease) both;
-}
-
 [data-qp-motion="enhanced"] .tools-section-pane,
 [data-qp-motion="enhanced"] .tools-mode-content-pane,
 [data-qp-motion="enhanced"] .qp-classification-object-pane {
-  animation: qp-horizontal-pane-enter var(--qp-motion-enhanced-view-duration) var(--qp-motion-ease) both;
+  animation: qp-horizontal-pane-enter var(--qp-motion-enhanced-pane-duration) var(--qp-motion-ease) both;
 }
 
 [data-qp-motion="enhanced"] .data-heatmap-loading-state .data-heatmap-cell,
@@ -53,24 +43,22 @@
 
 [data-qp-motion="enhanced"] .qp-nav-active-bg {
   transform: translate3d(0, calc(var(--qp-active-nav-index) * 3.125rem), 0);
-  transition: transform var(--qp-motion-enhanced-nav-bg-duration) var(--qp-motion-ease);
+  transition: transform var(--qp-motion-enhanced-nav-bg-duration) var(--qp-motion-enhanced-nav-bounce-ease);
 }
 
 [data-qp-motion="enhanced"] .qp-nav-active-indicator {
   transform: translate3d(0, calc(var(--qp-active-nav-index) * 3.125rem), 0);
-  transition: transform var(--qp-motion-enhanced-nav-indicator-duration) var(--qp-motion-enhanced-spring-ease);
+  transition: transform var(--qp-motion-enhanced-nav-indicator-duration) var(--qp-motion-enhanced-nav-bounce-ease);
 }
 
 [data-qp-motion="enhanced"] .tools-section-active-bg {
   transform: translate3d(0, calc(var(--tools-active-section-index) * 48px), 0);
-  transition: transform var(--qp-motion-enhanced-nav-indicator-duration) var(--qp-motion-enhanced-spring-ease);
+  transition: transform var(--qp-motion-enhanced-nav-indicator-duration) var(--qp-motion-enhanced-nav-bounce-ease);
 }
 
-:root[data-qp-motion="reduced"] .qp-motion-view-enter,
 :root[data-qp-motion="reduced"] .qp-motion-overlay-enter,
 :root[data-qp-motion="reduced"] .qp-motion-popover-enter,
 :root[data-qp-motion="reduced"] .qp-toast-entry,
-:root[data-qp-motion="reduced"] .qp-content-fade-in,
 :root[data-qp-motion="reduced"] .tools-section-pane,
 :root[data-qp-motion="reduced"] .tools-mode-content-pane,
 :root[data-qp-motion="reduced"] .qp-classification-object-pane,
@@ -95,34 +83,10 @@
   }
 }
 
-@keyframes qp-view-fade-in {
-  from {
-    opacity: 0;
-    transform: translate3d(0, var(--qp-view-transition-offset, 12px), 0);
-  }
-
-  to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-@keyframes qp-content-fade-in {
-  from {
-    opacity: 0;
-    transform: translate3d(0, 2px, 0);
-  }
-
-  to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-}
-
 @keyframes qp-horizontal-pane-enter {
   from {
     opacity: 0;
-    transform: translate3d(8px, 0, 0);
+    transform: translate3d(4px, 0, 0);
   }
 
   to {

--- a/tests/uiSmoke.test.ts
+++ b/tests/uiSmoke.test.ts
@@ -268,6 +268,7 @@ await runTest("app shell declares every primary desktop view", () => {
   const viewType = readUtf8("src/app/types/view.ts");
   const shell = readUtf8("src/app/AppShell.tsx");
   const sidebar = readUtf8("src/app/components/AppSidebar.tsx");
+  const motionCss = readUtf8("src/styles/motion.css");
 
   for (const view of EXPECTED_VIEWS) {
     assert.match(viewType, new RegExp(`"${view}"`));
@@ -276,17 +277,19 @@ await runTest("app shell declares every primary desktop view", () => {
   }
   assert.match(shell, /useQuietMotionPreference/);
   assert.match(shell, /data-qp-motion=\{quietMotionMode\}/);
-  assert.match(shell, /VIEW_ORDER/);
-  assert.match(shell, /viewTransitionStyle/);
-  assert.match(shell, /qp-view-transition-offset/);
+  assert.doesNotMatch(shell, /VIEW_ORDER/);
+  assert.doesNotMatch(shell, /viewTransitionStyle/);
+  assert.match(motionCss, /--qp-motion-enhanced-nav-bounce-ease/);
+  assert.doesNotMatch(shell, /qp-main-view-enter/);
+  assert.doesNotMatch(shell, /qp-motion-view-enter/);
   assert.doesNotMatch(shell, /qp-dynamic-effects-off/);
 });
 
-await runTest("motion preference treats enhanced motion as an explicit app opt-in", () => {
+await runTest("motion preference keeps reduced motion above enhanced motion", () => {
   assert.equal(resolveQuietMotionMode({
     enhancedMotionEnabled: true,
     prefersReducedMotion: true,
-  }), "enhanced");
+  }), "reduced");
   assert.equal(resolveQuietMotionMode({
     enhancedMotionEnabled: false,
     prefersReducedMotion: true,
@@ -327,9 +330,10 @@ await runTest("Data regular view avoids visible loading and skeleton branches", 
   assert.doesNotMatch(data, /renderStage/);
   assert.doesNotMatch(trendPanel, /Loader2|qp-spin/);
   assert.doesNotMatch(appTrendPanel, /Loader2|qp-spin/);
-  assert.match(trendPanel, /qp-content-fade-in/);
-  assert.match(appTrendPanel, /qp-content-fade-in/);
-  assert.match(heatmapPanel, /qp-content-fade-in|data-heatmap-loading-state|loading\?: boolean/);
+  assert.doesNotMatch(trendPanel, /qp-content-fade-in/);
+  assert.doesNotMatch(appTrendPanel, /qp-content-fade-in/);
+  assert.doesNotMatch(heatmapPanel, /qp-content-fade-in/);
+  assert.match(heatmapPanel, /data-heatmap-loading-state|loading\?: boolean/);
   assert.doesNotMatch(heatmapPanel, /UI_TEXT\.data\.less/);
   assert.doesNotMatch(heatmapPanel, /UI_TEXT\.data\.more/);
   assert.match(heatmapPanel, /data-heatmap-granularity/);


### PR DESCRIPTION
## Purpose

右侧主视图切换时总会有一个阴影，本来想参考 Fluent Design 设计风格的，但是这个动效速度调快调慢都不太合适，干脆把右侧主视图的动效给拔了

或许后续会有更合适的 UI 方案？反正目前先避免了这个不稳定的视觉噪点

Refs #37 

## Changes

- 移除了右侧主视图阴影切换动效
- 调整动效测试，覆盖主视图不再挂载切换动画

## Scope

### Included

- 右侧主视图切换动效
- 相关 UI smoke 测试

### Not Included

- 不调整页面布局
- 不修改跟踪逻辑
- 不修改本地数据结构

## Risk Review

<!--
Complete the relevant items. Use `N/A` when an area is not affected.
Call out changes to tracking, local data, privacy, security, migrations, backup, restore, cleanup, or external interfaces explicitly.
-->

- Tracking correctness: N/A
- Local data safety: N/A
- Privacy or security: N/A
- Compatibility and migration: N/A
- Failure and recovery behavior: N/A

## Validation

<!--
Check the commands that were run. See CONTRIBUTING.md for the required validation level.
Add focused tests or manual checks below when relevant.
-->

- [x] `npm run check`
- [x] `npm run check:full` for Rust, tracking, SQLite, runtime, or architecture-boundary changes
- [x] `npm run release:check` for release, changelog, updater, version, tag, or packaging changes
- [x] Added or updated focused tests for the changed behavior

## Screenshots

<!--
Add before/after screenshots for visible UI changes.
Include relevant empty, disabled, error, narrow-layout, light-theme, or dark-theme states when applicable.
Write `N/A` if the change has no visible UI impact.
-->

## Contributor Checklist

- [x] I read the relevant active project documents under `docs/`.
- [x] This pull request solves one coherent problem and excludes unrelated cleanup.
- [x] New behavior is placed under the correct owner and does not bypass architecture boundaries.
- [x] I rebased onto the latest `main`, or confirmed that the branch is compatible with it.
- [x] I documented security behavior for any local or network interface.
- [x] I used `Refs #N` instead of an issue-closing keyword unless explicitly requested.
