### PR TITLE
feat(tools): replace blocking alert modals with non-intrusive notification toasts

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -64,6 +64,7 @@ import {
   watchCurrentWindowMaximized,
 } from "../platform/desktop/windowControlGateway";
 import ToolsSidebarStatusEntry from "../features/tools/components/ToolsSidebarStatusEntry.tsx";
+import NotificationToastStack from "../features/tools/components/NotificationToastStack.tsx";
 import ToolAlertDialog from "../features/tools/components/ToolAlertDialog.tsx";
 import type { ToolsOpenTarget } from "../features/tools/types.ts";
 import {
@@ -471,6 +472,7 @@ function AppShellContent() {
       <div className="qp-shell flex-1 min-h-0 p-4 md:p-5 lg:p-6 flex gap-4 md:gap-5 lg:gap-6 overflow-hidden">
         <QuietToastStack toasts={toasts} />
         <ToolAlertDialog />
+        <NotificationToastStack />
         {dialogs}
         <AppSidebar
           currentView={currentView}

--- a/src/features/tools/components/NotificationToastStack.tsx
+++ b/src/features/tools/components/NotificationToastStack.tsx
@@ -1,0 +1,114 @@
+import { createPortal } from "react-dom";
+import { useCallback, useEffect, useRef } from "react";
+import { AlarmClock, BellRing, TimerReset, X } from "lucide-react";
+import { useToolAlerts } from "../hooks/useToolAlerts.ts";
+import type { ToolAlert } from "../../../shared/types/tools.ts";
+
+const AUTO_DISMISS_MS = 6000;
+
+function iconForAlert(alert: ToolAlert) {
+  if (alert.kind === "countdown") return <TimerReset size={16} />;
+  if (alert.kind === "pomodoro") return <AlarmClock size={16} />;
+  return <BellRing size={16} />;
+}
+
+export default function NotificationToastStack() {
+  const { alerts, dismissAlert } = useToolAlerts();
+  const timersRef = useRef<Map<string, number>>(new Map());
+  const hoveredRef = useRef<Set<string>>(new Set());
+  const alertsRef = useRef(alerts);
+  alertsRef.current = alerts;
+
+  const clearTimer = useCallback((alertId: string) => {
+    const id = timersRef.current.get(alertId);
+    if (id != null) {
+      window.clearTimeout(id);
+      timersRef.current.delete(alertId);
+    }
+  }, []);
+
+  const startTimer = useCallback((alertId: string) => {
+    if (hoveredRef.current.has(alertId)) return;
+    clearTimer(alertId);
+    const timerId = window.setTimeout(() => {
+      timersRef.current.delete(alertId);
+      dismissAlert(alertId);
+    }, AUTO_DISMISS_MS);
+    timersRef.current.set(alertId, timerId);
+  }, [clearTimer, dismissAlert]);
+
+  useEffect(() => {
+    for (const alert of alerts) {
+      if (!timersRef.current.has(alert.id)) {
+        startTimer(alert.id);
+      }
+    }
+  }, [alerts, startTimer]);
+
+  useEffect(() => {
+    return () => {
+      timersRef.current.forEach((id) => window.clearTimeout(id));
+      timersRef.current.clear();
+    };
+  }, []);
+
+  const handleDismiss = useCallback((alertId: string) => {
+    clearTimer(alertId);
+    dismissAlert(alertId);
+  }, [clearTimer, dismissAlert]);
+
+  const handleMouseEnter = useCallback((alertId: string) => {
+    hoveredRef.current.add(alertId);
+    clearTimer(alertId);
+  }, [clearTimer]);
+
+  const handleMouseLeave = useCallback((alertId: string) => {
+    hoveredRef.current.delete(alertId);
+    if (alertsRef.current.some((a) => a.id === alertId)) {
+      startTimer(alertId);
+    }
+  }, [startTimer]);
+
+  const toastAlerts = alerts.filter((a) => a.kind !== "pomodoro");
+  if (toastAlerts.length === 0) return null;
+
+  const content = (
+    <div className="pointer-events-none fixed bottom-4 right-4 z-[80] flex w-[340px] max-w-[calc(100vw-2rem)] flex-col gap-2">
+      {toastAlerts.map((alert) => (
+        <div
+          key={alert.id}
+          className="qp-toast-entry pointer-events-auto rounded-[var(--qp-radius-control)] border border-[var(--qp-border-subtle)] bg-[var(--qp-bg-panel)] p-2.5 shadow-[var(--qp-shadow-toast)]"
+          onMouseEnter={() => handleMouseEnter(alert.id)}
+          onMouseLeave={() => handleMouseLeave(alert.id)}
+        >
+          <div className="flex items-start gap-2.5">
+            <div className="mt-0.5 shrink-0 text-[var(--qp-text-tertiary)]" aria-hidden="true">
+              {iconForAlert(alert)}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-[13px] font-medium leading-[1.4] text-[var(--qp-text-primary)]">
+                {alert.title}
+              </div>
+              {alert.body && (
+                <div className="mt-0.5 line-clamp-2 text-[12px] leading-[1.4] text-[var(--qp-text-secondary)]">
+                  {alert.body}
+                </div>
+              )}
+            </div>
+            <button
+              type="button"
+              className="mt-0.5 shrink-0 p-0.5 text-[var(--qp-text-tertiary)] opacity-50 hover:opacity-100"
+              onClick={() => handleDismiss(alert.id)}
+              aria-label="Dismiss"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
+  if (typeof document === "undefined") return null;
+  return createPortal(content, document.body);
+}

--- a/src/features/tools/components/ToolAlertDialog.tsx
+++ b/src/features/tools/components/ToolAlertDialog.tsx
@@ -22,61 +22,59 @@ function alertIcon(alert: ToolAlert): ReactNode {
 }
 
 export default function ToolAlertDialog() {
-  const { activeAlert, dismissActiveAlert } = useToolAlerts();
+  const { alerts, dismissAlert } = useToolAlerts();
+  const pomodoroAlert = alerts.find((a) => a.kind === "pomodoro") ?? null;
   const [pausingPomodoro, setPausingPomodoro] = useState(false);
-  const title = activeAlert?.title.trim() || UI_TEXT.tools.notificationStatus;
-  const message = activeAlert?.body.trim() || UI_TEXT.tools.defaultReminderLabel;
-  const occurredAtLabel = activeAlert
-    ? UI_TEXT.tools.alertOccurredAt(formatAlertTime(activeAlert.occurredAt))
+  const title = pomodoroAlert?.title.trim() || UI_TEXT.tools.notificationStatus;
+  const message = pomodoroAlert?.body.trim() || UI_TEXT.tools.defaultReminderLabel;
+  const occurredAtLabel = pomodoroAlert
+    ? UI_TEXT.tools.alertOccurredAt(formatAlertTime(pomodoroAlert.occurredAt))
     : "";
-  const canPausePomodoro = activeAlert?.kind === "pomodoro";
   const handlePausePomodoro = useCallback(async () => {
-    if (activeAlert?.kind !== "pomodoro" || pausingPomodoro) return;
+    if (!pomodoroAlert || pausingPomodoro) return;
 
     setPausingPomodoro(true);
     try {
       await ToolsRuntimeService.pausePomodoro();
-      dismissActiveAlert();
+      dismissAlert(pomodoroAlert.id);
     } catch (error) {
       console.warn("pause pomodoro from alert failed", error);
     } finally {
       setPausingPomodoro(false);
     }
-  }, [activeAlert?.kind, dismissActiveAlert, pausingPomodoro]);
+  }, [pomodoroAlert, dismissAlert, pausingPomodoro]);
 
   return (
     <QuietDialog
-      open={Boolean(activeAlert)}
+      open={Boolean(pomodoroAlert)}
       title={title}
       closeOnBackdrop={false}
-      onClose={dismissActiveAlert}
+      onClose={() => pomodoroAlert && dismissAlert(pomodoroAlert.id)}
       surfaceClassName="tools-alert-dialog-surface"
       actions={(
         <>
-          {canPausePomodoro && (
-            <button
-              type="button"
-              className="qp-button-secondary qp-dialog-action disabled:cursor-not-allowed disabled:opacity-50"
-              onClick={() => void handlePausePomodoro()}
-              disabled={pausingPomodoro}
-            >
-              {pausingPomodoro ? UI_TEXT.tools.alertPausingPomodoro : UI_TEXT.tools.alertPausePomodoro}
-            </button>
-          )}
+          <button
+            type="button"
+            className="qp-button-secondary qp-dialog-action disabled:cursor-not-allowed disabled:opacity-50"
+            onClick={() => void handlePausePomodoro()}
+            disabled={pausingPomodoro}
+          >
+            {pausingPomodoro ? UI_TEXT.tools.alertPausingPomodoro : UI_TEXT.tools.alertPausePomodoro}
+          </button>
           <button
             type="button"
             className="qp-button-primary qp-dialog-action"
-            onClick={dismissActiveAlert}
+            onClick={() => pomodoroAlert && dismissAlert(pomodoroAlert.id)}
           >
             {UI_TEXT.tools.alertDismiss}
           </button>
         </>
       )}
     >
-      {activeAlert && (
+      {pomodoroAlert && (
         <div className="tools-alert-dialog-body">
           <div className="tools-alert-dialog-icon" aria-hidden="true">
-            {alertIcon(activeAlert)}
+            {alertIcon(pomodoroAlert)}
           </div>
           <div className="tools-alert-dialog-copy">
             <p className="tools-alert-dialog-message">{message}</p>

--- a/src/features/tools/hooks/useToolAlerts.ts
+++ b/src/features/tools/hooks/useToolAlerts.ts
@@ -51,21 +51,25 @@ export function useToolAlerts() {
     };
   }, []);
 
+  const dismissAlert = useCallback((alertId: string) => {
+    setAlerts((current) => current.filter((a) => a.id !== alertId));
+    void ToolsRuntimeService.dismissToolAlert(alertId).catch((error) => {
+      console.warn("dismiss tool alert failed", error);
+    });
+  }, []);
+
   const activeAlert = alerts[0] ?? null;
 
   const dismissActiveAlert = useCallback(() => {
     if (!activeAlert) return;
-
-    const alertId = activeAlert.id;
-    setAlerts((current) => current.filter((alert) => alert.id !== alertId));
-    void ToolsRuntimeService.dismissToolAlert(alertId).catch((error) => {
-      console.warn("dismiss tool alert failed", error);
-    });
-  }, [activeAlert]);
+    dismissAlert(activeAlert.id);
+  }, [activeAlert, dismissAlert]);
 
   return useMemo(() => ({
+    alerts,
     activeAlert,
+    dismissAlert,
     dismissActiveAlert,
     pendingCount: alerts.length,
-  }), [activeAlert, alerts.length, dismissActiveAlert]);
+  }), [alerts, activeAlert, dismissAlert, dismissActiveAlert, alerts.length]);
 }

--- a/tests/uiSmoke.test.ts
+++ b/tests/uiSmoke.test.ts
@@ -821,7 +821,7 @@ await runTest("tracker health polling is foreground gated without resubscribing 
 await runTest("pomodoro alert dialog offers a pause action without changing other alerts", () => {
   const dialog = readUtf8("src/features/tools/components/ToolAlertDialog.tsx");
 
-  assert.match(dialog, /activeAlert\?\.kind === "pomodoro"/);
+  assert.match(dialog, /alerts\.find\(/);
   assert.match(dialog, /ToolsRuntimeService\.pausePomodoro/);
   assert.match(dialog, /UI_TEXT\.tools\.alertPausePomodoro/);
   assert.match(dialog, /UI_TEXT\.tools\.alertDismiss/);


### PR DESCRIPTION
## Purpose

Replace the full-screen blocking `ToolAlertDialog` for non-pomodoro tool alerts (reminder, countdown, software reminder) with a non-intrusive in-app notification toast stack, as requested in the PR #43 review. Pomodoro alerts retain the strong modal dialog because they require an action (pause button).

Refs #43

## Changes

- **NotificationToastStack** (new, `features/tools/components/`): Bottom‑right floating toast overlay rendered via React portal. Appears for non‑pomodoro alerts only. Auto‑dismisses after 6 seconds, pauses on hover, restarts on leave. Follows Quiet Pro tokens (`--qp-bg-panel`, `--qp-shadow-toast`, `--qp-radius-control`, etc.) and uses the existing `qp-toast-entry` animation system.

- **useToolAlerts hook** (`features/tools/hooks/`): Exposes `alerts` (full array) and `dismissAlert(id)` (dismiss by ID) alongside the existing backward‑compatible `activeAlert`, `dismissActiveAlert`, and `pendingCount`.

- **ToolAlertDialog** (`features/tools/components/`): Scoped to pomodoro alerts only (`alerts.find(kind === "pomodoro")`). Non‑pomodoro alerts no longer trigger the strong modal.

- **AppShell** (`app/AppShell.tsx`): `<NotificationToastStack />` added alongside `<QuietToastStack>` and `<ToolAlertDialog>`.

## Scope

### Included

- Non‑blocking floating toast for reminder, countdown, and software_reminder alerts
- Pomodoro alerts still shown as strong modal with pause/dismiss actions
- Shared alert state: dismissing a toast clears the same alert from the dialog and vice‑versa
- Entry animation aligned with Quiet Toast Stack (`qp-toast-entry`)
- Full keyboard accessibility on dismiss button (global `focus-visible` style applies)

### Not Included

- No system notifications, WinRT, AUMID, registry, or icon files
- No new settings or toggles
- No Rust or architecture boundary changes
- No changes to pomodoro timer, reminder scheduling, or any tracking behavior
- No macOS/Linux notification support (unchanged, still uses existing in‑app path)

## Risk Review

- **Tracking correctness**: N/A. Display‑only change. Alert dismissal calls the existing `cmd_dismiss_tool_alert` command which delegates to the Tools engine repository.
- **Local data safety**: N/A. No SQLite, persistence, or data mutation was added or modified.
- **Privacy or security**: N/A. No network, credential, or user data involved.
- **Compatibility and migration**: N/A. No settings, database schema, or file format changes. The `useToolAlerts` hook return is backward‑compatible.
- **Failure and recovery behavior**: A failing `dismissToolAlert` is logged and ignored (same as before). Timer mismanagement is self‑contained per mount cycle via cleanup `useEffect`.

## Validation

- [x] `npm run check:full`

## Screenshots

<img width="2189" height="1442" alt="PixPin_2026-07-13_11-40-39" src="https://github.com/user-attachments/assets/5cb95773-c970-40e4-8e3d-7eebadf3d2c8" />

## Contributor Checklist

- [x] I read the relevant active project documents under `docs/`.
- [x] This pull request solves one coherent problem and excludes unrelated cleanup.
- [x] The commits are reviewable; oversized changes were split coherently or explicitly approved with an indivisibility explanation.
- [x] New behavior is placed under the correct owner and does not bypass architecture boundaries.
- [x] I rebased onto the latest `main`, or confirmed that the branch is compatible with it.
- [x] I documented security behavior for any local or network interface.
- [x] I used `Refs #N` instead of an issue-closing keyword unless explicitly requested.