### PR TITLE
refactor(data): remove standalone DataAppTrendPanel and simplify Data page

### DIFF
--- a/src/features/data/components/Data.tsx
+++ b/src/features/data/components/Data.tsx
@@ -1,17 +1,13 @@
 import { startTransition, type MouseEvent, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { BarChart3 } from "lucide-react";
 import { UI_TEXT } from "../../../shared/copy/index.ts";
-import { useRequestedAppIcons } from "../../../shared/hooks/useRequestedAppIcons.ts";
 import type { AppLanguage } from "../../../shared/settings/appSettings.ts";
 import {
-  buildDataAppTrendViewModel,
-  buildDataAppTrendViewModelFromAggregate,
   buildDataTrendAggregateContext,
   buildDataTrendViewModelFromAggregate,
   buildDataTrendViewModel,
   getCachedDataHeatmapSessions,
   getCachedEarliestSessionStartTime,
-  type DataAppTrendViewModel,
   type DataTrendViewModel,
   type AggregateSessionRecord,
   loadDataHeatmapSnapshot,
@@ -34,15 +30,8 @@ import { resolveTrendDateFromChartEvent } from "../services/dataChartInteraction
 import type { DataTrendSnapshot } from "../services/dataTrendSnapshot.ts";
 import type { DataTrendRangeSelection } from "../services/dataTrendRange.ts";
 import { useDataTrendSnapshot } from "../hooks/useDataTrendSnapshot.ts";
-import { loadDataIconsForExecutables } from "../services/dataIconService.ts";
 import { scheduleDataWorkAfterFirstPaint } from "../services/dataFirstPaintScheduler.ts";
-import {
-  dedupeDataAppOptions,
-  filterDataAppOptionsForQuery,
-  resolveDataAppSearchSelection,
-} from "../services/dataAppSearch.ts";
 import DataTrendPanel from "./DataTrendPanel.tsx";
-import DataAppTrendPanel from "./DataAppTrendPanel.tsx";
 import DataHeatmapPanel, { type HeatmapGranularity } from "./DataHeatmapPanel.tsx";
 
 interface Props {
@@ -56,19 +45,12 @@ interface Props {
 }
 
 type DataChartDimension = { width: number; height: number };
-type DataChartDimensionKey = "overviewTrend" | "appTrend";
+type DataChartDimensionKey = "overviewTrend";
 const CACHED_DATA_HEATMAP_REFRESH_DELAY_MS = 320;
 const CACHED_DATA_HEATMAP_REFRESH_IDLE_TIMEOUT_MS = 1_500;
 const DATA_OPEN_PREWARM_DELAY_MS = 500;
 const DATA_OPEN_PREWARM_IDLE_TIMEOUT_MS = 2_000;
-const EMPTY_DATA_ICON_EXE_NAMES: string[] = [];
-const EMPTY_DATA_APP_OPTIONS: DataAppTrendViewModel["appOptions"] = [];
-const EMPTY_DATA_APP_TREND_POINTS: DataAppTrendViewModel["chartData"] = [];
 const EMPTY_HEATMAP_ROWS: ReturnType<typeof buildActivityHeatmap> = [];
-const DEFAULT_DATA_APP_CHART_AXIS: DataAppTrendViewModel["chartAxis"] = {
-  domainMax: 3,
-  ticks: [0, 1, 2, 3],
-};
 const dataChartDimensionCache: Partial<Record<DataChartDimensionKey, DataChartDimension>> = {};
 const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
@@ -91,16 +73,6 @@ function getOverviewTrendChartInitialDimension(): DataChartDimension {
     ? 852
     : clampNumber(viewport.width - 296, 560, 1280);
   const height = viewport.width >= 1536 && viewport.height >= 900 ? 214 : viewport.width <= 900 ? 140 : 168;
-
-  return { width, height };
-}
-
-function getAppTrendChartInitialDimension(): DataChartDimension {
-  const viewport = getDataViewportSize();
-  const width = viewport.width >= 1900
-    ? 852
-    : clampNumber(viewport.width - 520, 420, 860);
-  const height = viewport.width >= 1900 ? 200 : viewport.width <= 900 ? 172 : 210;
 
   return { width, height };
 }
@@ -151,7 +123,6 @@ function useDataChartInitialDimension(
 }
 
 export default function Data({
-  icons,
   refreshKey = 0,
   loadDataTrendSnapshot,
   mappingVersion = 0,
@@ -161,9 +132,6 @@ export default function Data({
   const today = new Date();
   const currentYear = today.getFullYear();
   const [selectedTrendRange, setSelectedTrendRange] = useState<DataTrendRangeSelection>({ kind: "rolling", days: 7 });
-  const [selectedAppTrendRange, setSelectedAppTrendRange] = useState<DataTrendRangeSelection>({ kind: "rolling", days: 7 });
-  const [selectedAppKey, setSelectedAppKey] = useState<string | null>(null);
-  const [appSearchQuery, setAppSearchQuery] = useState("");
   const [freshReadModelsReady, setFreshReadModelsReady] = useState(false);
   const [initialCachedHeatmapSessions] = useState(() => getCachedDataHeatmapSessions("recent", Date.now()));
   const [bootstrapSnapshot, setBootstrapSnapshot] = useState<DataBootstrapSnapshot | null>(
@@ -171,11 +139,6 @@ export default function Data({
   );
   const overviewTrend = useDataTrendSnapshot({
     selection: selectedTrendRange,
-    refreshKey,
-    loadSnapshot: loadDataTrendSnapshot,
-  });
-  const appTrend = useDataTrendSnapshot({
-    selection: selectedAppTrendRange,
     refreshKey,
     loadSnapshot: loadDataTrendSnapshot,
   });
@@ -187,35 +150,22 @@ export default function Data({
   const [yearSessions, setYearSessions] = useState<AggregateSessionRecord[]>(
     () => initialCachedHeatmapSessions ?? [],
   );
-  const [yearSessionsView, setYearSessionsView] = useState<HeatmapSelection | null>(
-    initialCachedHeatmapSessions ? "recent" : null,
-  );
   const [heatmapLoading, setHeatmapLoading] = useState(!initialCachedHeatmapSessions);
   const overviewTrendChart = useDataChartInitialDimension(
     "overviewTrend",
     getOverviewTrendChartInitialDimension,
-  );
-  const appTrendChart = useDataChartInitialDimension(
-    "appTrend",
-    getAppTrendChartInitialDimension,
   );
   const nowMs = overviewTrend.nowMs;
   const lastTrendViewModelRef = useRef<{
     rangeCacheKey: string;
     viewModel: DataTrendViewModel;
   } | null>(null);
-  const lastAppTrendViewModelRef = useRef<{
-    rangeCacheKey: string;
-    viewModel: DataAppTrendViewModel;
-  } | null>(null);
   const lastHeatmapRowsRef = useRef<{
     selection: HeatmapSelection;
     rows: ReturnType<typeof buildActivityHeatmap>;
   } | null>(null);
-  const appListRef = useRef<HTMLDivElement | null>(null);
   const hasFetchedHeatmapOnceRef = useRef(Boolean(initialCachedHeatmapSessions));
   const activeTrendDateRef = useRef<string | null>(null);
-  const activeAppTrendDateRef = useRef<string | null>(null);
   const hasInitialBootstrapSnapshotRef = useRef(Boolean(bootstrapSnapshot));
   useEffect(() => {
     if (bootstrapSnapshot) return;
@@ -254,7 +204,6 @@ export default function Data({
         startTransition(() => {
           setEarliestStartTime(snapshot.earliestStartTime);
           setYearSessions(snapshot.sessions);
-          setYearSessionsView(selectedHeatmapView);
         });
         hasFetchedHeatmapOnceRef.current = true;
 
@@ -279,7 +228,6 @@ export default function Data({
       if (cachedSessions) {
         startTransition(() => {
           setYearSessions(cachedSessions);
-          setYearSessionsView(selectedHeatmapView);
         });
         hasFetchedHeatmapOnceRef.current = true;
         setHeatmapLoading(false);
@@ -313,7 +261,6 @@ export default function Data({
     && Boolean(matchingBootstrapSnapshot)
     && !freshReadModelsReady;
   const overviewTrendSnapshotForViewModel = shouldDeferRuntimeReadModels ? null : overviewTrend.snapshot;
-  const appTrendSnapshotForViewModel = shouldDeferRuntimeReadModels ? null : appTrend.snapshot;
 
   useEffect(() => {
     if (!hasInitialBootstrapSnapshotRef.current || !matchingBootstrapSnapshot || freshReadModelsReady) {
@@ -325,29 +272,16 @@ export default function Data({
     });
   }, [freshReadModelsReady, matchingBootstrapSnapshot]);
 
-  const sharedTrendAggregateContext = useMemo(() => {
-    if (!overviewTrendSnapshotForViewModel || !appTrendSnapshotForViewModel) return null;
-    const overviewRange = overviewTrendSnapshotForViewModel.range;
-    const appRange = appTrendSnapshotForViewModel.range;
-    if (
-      overviewRange.cacheKey !== appRange.cacheKey
-      || overviewRange.label !== appRange.label
-      || overviewRange.granularity !== appRange.granularity
-      || overviewRange.dayCount !== appRange.dayCount
-      || overviewTrendSnapshotForViewModel.sessions !== appTrendSnapshotForViewModel.sessions
-    ) {
-      return null;
-    }
-
+  const overviewAggregateContext = useMemo(() => {
+    if (!overviewTrendSnapshotForViewModel) return null;
     return buildDataTrendAggregateContext(
       overviewTrendSnapshotForViewModel.sessions,
-      overviewRange,
+      overviewTrendSnapshotForViewModel.range,
       overviewTrend.nowMs,
     );
   // Data aggregators read module-level locale/mapping state; these tokens explicitly invalidate that cache.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    appTrendSnapshotForViewModel,
     mappingVersion,
     overviewTrend.nowMs,
     overviewTrendSnapshotForViewModel,
@@ -355,8 +289,8 @@ export default function Data({
   ]);
 
   const trendViewModel = useMemo(() => {
-    if (sharedTrendAggregateContext) {
-      return buildDataTrendViewModelFromAggregate(sharedTrendAggregateContext);
+    if (overviewAggregateContext) {
+      return buildDataTrendViewModelFromAggregate(overviewAggregateContext);
     }
     if (!overviewTrendSnapshotForViewModel) return null;
     return buildDataTrendViewModel(
@@ -370,7 +304,7 @@ export default function Data({
     mappingVersion,
     overviewTrend.nowMs,
     overviewTrendSnapshotForViewModel,
-    sharedTrendAggregateContext,
+    overviewAggregateContext,
     uiLanguage,
   ]);
   if (trendViewModel) {
@@ -387,140 +321,7 @@ export default function Data({
       ? lastTrendViewModelRef.current.viewModel
       : null)
     ?? bootstrapTrendViewModel;
-  const appTrendViewModel = useMemo(() => {
-    if (sharedTrendAggregateContext) {
-      return buildDataAppTrendViewModelFromAggregate(sharedTrendAggregateContext, selectedAppKey);
-    }
-    if (!appTrendSnapshotForViewModel) return null;
-    return buildDataAppTrendViewModel(
-      appTrendSnapshotForViewModel.sessions,
-      appTrendSnapshotForViewModel.range,
-      appTrend.nowMs,
-      selectedAppKey,
-    );
-  // App trend view models read module-level locale/mapping state; these tokens explicitly invalidate that cache.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    appTrend.nowMs,
-    appTrendSnapshotForViewModel,
-    mappingVersion,
-    selectedAppKey,
-    sharedTrendAggregateContext,
-    uiLanguage,
-  ]);
-  const bootstrapAppTrendViewModel = matchingBootstrapSnapshot?.appRangeCacheKey === appTrend.resolvedRange.cacheKey
-    ? matchingBootstrapSnapshot.appTrendViewModel
-    : null;
-  if (appTrendViewModel) {
-    lastAppTrendViewModelRef.current = {
-      rangeCacheKey: appTrend.resolvedRange.cacheKey,
-      viewModel: appTrendViewModel,
-    };
-  }
-  const visibleAppTrendViewModel = appTrendViewModel
-    ?? (lastAppTrendViewModelRef.current?.rangeCacheKey === appTrend.resolvedRange.cacheKey
-      ? lastAppTrendViewModelRef.current.viewModel
-      : null)
-    ?? bootstrapAppTrendViewModel;
-  const dataIconExeNames = useMemo(
-    () => visibleAppTrendViewModel?.appOptions.map((app) => app.exeName) ?? EMPTY_DATA_ICON_EXE_NAMES,
-    [visibleAppTrendViewModel?.appOptions],
-  );
-  const snapshotDataIcons = useMemo(() => ({
-    ...(overviewTrend.snapshot?.icons ?? {}),
-    ...(appTrend.snapshot?.icons ?? {}),
-  }), [appTrend.snapshot, overviewTrend.snapshot]);
-  const baseDataIcons = useMemo(() => ({
-    ...icons,
-    ...snapshotDataIcons,
-  }), [icons, snapshotDataIcons]);
-  const handleDataIconsError = useCallback((error: unknown) => {
-    console.warn("Failed to refresh data app icons:", error);
-  }, []);
-  const dataIcons = useRequestedAppIcons({
-    baseIcons: baseDataIcons,
-    exeNames: dataIconExeNames,
-    loadIcons: loadDataIconsForExecutables,
-    onError: handleDataIconsError,
-  });
 
-  useEffect(() => {
-    if (selectedAppKey !== null) return;
-
-    const defaultAppKey = appTrendViewModel?.selectedApp?.appKey;
-    if (defaultAppKey) {
-      setSelectedAppKey(defaultAppKey);
-    }
-  }, [appTrendViewModel?.selectedApp?.appKey, selectedAppKey]);
-
-  const dedupedAppOptions = useMemo(() => {
-    if (!visibleAppTrendViewModel) return EMPTY_DATA_APP_OPTIONS;
-    return dedupeDataAppOptions(visibleAppTrendViewModel.appOptions);
-  }, [visibleAppTrendViewModel]);
-  const filteredAppOptions = useMemo(() => (
-    filterDataAppOptionsForQuery(dedupedAppOptions, appSearchQuery)
-  ), [appSearchQuery, dedupedAppOptions]);
-
-  const hasAppSearchQuery = appSearchQuery.trim().length > 0;
-  const appTrendSelectedAppMatchesSearch = !hasAppSearchQuery
-    || Boolean(
-      visibleAppTrendViewModel?.selectedApp
-      && filteredAppOptions.some((app) => app.appKey === visibleAppTrendViewModel.selectedApp?.appKey),
-    );
-  const appTrendSelectionHiddenBySearch = hasAppSearchQuery && !appTrendSelectedAppMatchesSearch;
-  const selectedAppTrendApp = appTrendSelectionHiddenBySearch ? null : visibleAppTrendViewModel?.selectedApp;
-  const appTrendChartData = useMemo(() => {
-    if (appTrendSelectionHiddenBySearch && visibleAppTrendViewModel) {
-      return visibleAppTrendViewModel.chartData.map((point) => ({ ...point, duration: 0, hours: 0 }));
-    }
-    return visibleAppTrendViewModel?.chartData ?? EMPTY_DATA_APP_TREND_POINTS;
-  }, [appTrendSelectionHiddenBySearch, visibleAppTrendViewModel]);
-  const appTrendChartAxis = useMemo(() => (
-    appTrendSelectionHiddenBySearch
-      ? DEFAULT_DATA_APP_CHART_AXIS
-      : visibleAppTrendViewModel?.chartAxis ?? DEFAULT_DATA_APP_CHART_AXIS
-  ), [appTrendSelectionHiddenBySearch, visibleAppTrendViewModel?.chartAxis]);
-  const appTrendPeakDay = appTrendSelectionHiddenBySearch ? null : (visibleAppTrendViewModel?.peakDay ?? null);
-
-  useEffect(() => {
-    if (!hasAppSearchQuery || !visibleAppTrendViewModel) return;
-    const nextSelectedAppKey = resolveDataAppSearchSelection({
-      wasSearching: false,
-      isSearching: hasAppSearchQuery,
-      selectedAppKey,
-      selectedApp: visibleAppTrendViewModel.selectedApp,
-      filteredOptions: filteredAppOptions,
-    });
-    if (nextSelectedAppKey !== undefined && selectedAppKey !== nextSelectedAppKey) {
-      setSelectedAppKey(nextSelectedAppKey);
-    }
-  }, [filteredAppOptions, hasAppSearchQuery, selectedAppKey, visibleAppTrendViewModel]);
-
-  useLayoutEffect(() => {
-    appListRef.current?.scrollTo({ top: 0 });
-  }, [hasAppSearchQuery]);
-
-  const handleAppSearchQueryChange = useCallback((nextQuery: string) => {
-    const wasSearching = appSearchQuery.trim().length > 0;
-    const isSearching = nextQuery.trim().length > 0;
-    setAppSearchQuery(nextQuery);
-    appListRef.current?.scrollTo({ top: 0 });
-    const nextSelectedAppKey = resolveDataAppSearchSelection({
-      wasSearching,
-      isSearching,
-      selectedAppKey,
-      selectedApp: visibleAppTrendViewModel?.selectedApp,
-      filteredOptions: filterDataAppOptionsForQuery(dedupedAppOptions, nextQuery),
-    });
-    if (nextSelectedAppKey !== undefined && selectedAppKey !== nextSelectedAppKey) {
-      setSelectedAppKey(nextSelectedAppKey);
-    }
-  }, [
-    appSearchQuery,
-    dedupedAppOptions,
-    selectedAppKey,
-    visibleAppTrendViewModel?.selectedApp,
-  ]);
   const shouldDeferHeatmapRows = Boolean(
     hasInitialBootstrapSnapshotRef.current
     && matchingBootstrapSnapshot?.heatmapSelection === selectedHeatmapView
@@ -530,8 +331,7 @@ export default function Data({
     if (shouldDeferHeatmapRows) return null;
     return buildActivityHeatmap(yearSessions, selectedHeatmapView, nowMs);
   }, [nowMs, selectedHeatmapView, shouldDeferHeatmapRows, yearSessions]);
-  const hasHeatmapRowsForSelectedView = yearSessionsView === selectedHeatmapView;
-  if (heatmapRows && !heatmapLoading && hasHeatmapRowsForSelectedView) {
+  if (heatmapRows && !heatmapLoading) {
     lastHeatmapRowsRef.current = {
       selection: selectedHeatmapView,
       rows: heatmapRows,
@@ -540,12 +340,12 @@ export default function Data({
   const bootstrapHeatmapRows = matchingBootstrapSnapshot?.heatmapSelection === selectedHeatmapView
     ? matchingBootstrapSnapshot.heatmapRows
     : null;
-  const freshHeatmapRows = heatmapRows && !heatmapLoading && hasHeatmapRowsForSelectedView ? heatmapRows : null;
+  const freshHeatmapRows = heatmapRows && !heatmapLoading ? heatmapRows : null;
   const lastHeatmapRows = lastHeatmapRowsRef.current?.selection === selectedHeatmapView
     ? lastHeatmapRowsRef.current.rows
     : null;
   const canUseBootstrapHeatmap = Boolean(
-    bootstrapHeatmapRows && (shouldDeferHeatmapRows || heatmapLoading || !hasHeatmapRowsForSelectedView),
+    bootstrapHeatmapRows && (shouldDeferHeatmapRows || heatmapLoading),
   );
   const shouldBuildHeatmapPlaceholderRows = !freshHeatmapRows && !lastHeatmapRows && !canUseBootstrapHeatmap;
   const heatmapPlaceholderRows = useMemo(() => (
@@ -587,9 +387,6 @@ export default function Data({
     ? UI_TEXT.data.recentYear
     : String(selectedHeatmapView);
   const canOpenTrendHistory = visibleTrendViewModel?.granularity === "day" && Boolean(onOpenHistoryDate);
-  const canOpenAppTrendHistory = visibleAppTrendViewModel?.granularity === "day"
-    && !appTrendSelectionHiddenBySearch
-    && Boolean(onOpenHistoryDate);
   const handleTrendMouseMove = useCallback((event: unknown) => {
     activeTrendDateRef.current = canOpenTrendHistory && visibleTrendViewModel
       ? resolveTrendDateFromChartEvent(event, visibleTrendViewModel.chartData)
@@ -601,17 +398,6 @@ export default function Data({
       onOpenHistoryDate?.(dateKey);
     }
   }, [canOpenTrendHistory, onOpenHistoryDate]);
-  const handleAppTrendMouseMove = useCallback((event: unknown) => {
-    activeAppTrendDateRef.current = canOpenAppTrendHistory
-      ? resolveTrendDateFromChartEvent(event, appTrendChartData)
-      : null;
-  }, [appTrendChartData, canOpenAppTrendHistory]);
-  const handleAppTrendDoubleClick = useCallback(() => {
-    const dateKey = activeAppTrendDateRef.current;
-    if (dateKey && canOpenAppTrendHistory) {
-      onOpenHistoryDate?.(dateKey);
-    }
-  }, [canOpenAppTrendHistory, onOpenHistoryDate]);
   const preventChartTextSelection = useCallback((event: MouseEvent<HTMLDivElement>, canOpenHistory: boolean) => {
     if (canOpenHistory && event.detail > 1) {
       event.preventDefault();
@@ -628,38 +414,22 @@ export default function Data({
     event.preventDefault();
     handleTrendDoubleClick();
   }, [canOpenTrendHistory, handleTrendDoubleClick]);
-  const handleAppTrendDoubleClickCapture = useCallback((event: MouseEvent<HTMLDivElement>) => {
-    if (!canOpenAppTrendHistory) {
-      return;
-    }
-
-    event.preventDefault();
-    handleAppTrendDoubleClick();
-  }, [canOpenAppTrendHistory, handleAppTrendDoubleClick]);
-  const handleAppTrendMouseDownCapture = useCallback((event: MouseEvent<HTMLDivElement>) => {
-    preventChartTextSelection(event, canOpenAppTrendHistory);
-  }, [canOpenAppTrendHistory, preventChartTextSelection]);
   const handleTrendMouseLeave = useCallback(() => {
     activeTrendDateRef.current = null;
   }, []);
-  const handleAppTrendMouseLeave = useCallback(() => {
-    activeAppTrendDateRef.current = null;
-  }, []);
 
   useEffect(() => {
-    if (!trendViewModel || !appTrendViewModel || !heatmapRows) return;
-    if (heatmapLoading || yearSessionsView !== selectedHeatmapView) return;
-    if (!overviewTrend.snapshot || !appTrend.snapshot) return;
+    if (!trendViewModel || !heatmapRows) return;
+    if (heatmapLoading) return;
+    if (!overviewTrend.snapshot) return;
 
     const snapshot: DataBootstrapSnapshot = {
       createdAtMs: Date.now(),
       overviewRangeCacheKey: overviewTrend.snapshot.range.cacheKey,
-      appRangeCacheKey: appTrend.snapshot.range.cacheKey,
       heatmapSelection: selectedHeatmapView,
       mappingVersion,
       uiLanguage,
       overviewTrendViewModel: trendViewModel,
-      appTrendViewModel,
       heatmapRows,
       earliestStartTime,
     };
@@ -667,8 +437,6 @@ export default function Data({
     setBootstrapSnapshot(snapshot);
     void saveDataBootstrapSnapshot(snapshot);
   }, [
-    appTrend.snapshot,
-    appTrendViewModel,
     earliestStartTime,
     heatmapLoading,
     heatmapRows,
@@ -677,7 +445,6 @@ export default function Data({
     selectedHeatmapView,
     trendViewModel,
     uiLanguage,
-    yearSessionsView,
   ]);
 
   return (
@@ -718,30 +485,6 @@ export default function Data({
             loading={heatmapLoading}
           />
         </div>
-
-        <DataAppTrendPanel
-          selection={selectedAppTrendRange}
-          viewModel={visibleAppTrendViewModel}
-          selectedApp={selectedAppTrendApp}
-          filteredAppOptions={filteredAppOptions}
-          appSearchQuery={appSearchQuery}
-          hasAppSearchQuery={hasAppSearchQuery}
-          chartData={appTrendChartData}
-          chartAxis={appTrendChartAxis}
-          peakDay={appTrendPeakDay}
-          dataIcons={dataIcons}
-          appListRef={appListRef}
-          chartRef={appTrendChart.chartRef}
-          initialDimension={appTrendChart.initialDimension}
-          canOpenHistory={canOpenAppTrendHistory}
-          onSelectionChange={setSelectedAppTrendRange}
-          onSearchQueryChange={handleAppSearchQueryChange}
-          onAppSelect={setSelectedAppKey}
-          onMouseDownCapture={handleAppTrendMouseDownCapture}
-          onDoubleClickCapture={handleAppTrendDoubleClickCapture}
-          onMouseMove={handleAppTrendMouseMove}
-          onMouseLeave={handleAppTrendMouseLeave}
-        />
       </div>
     </div>
   );

--- a/src/features/data/services/dataBootstrapSnapshot.ts
+++ b/src/features/data/services/dataBootstrapSnapshot.ts
@@ -5,7 +5,6 @@ import {
   saveDataBootstrapSnapshotPayload,
 } from "../../../platform/persistence/dataBootstrapSnapshotStore.ts";
 import type {
-  DataAppTrendViewModel,
   DataTrendViewModel,
 } from "./dataReadModel.ts";
 import type { HeatmapSelection, HeatmapWeek } from "./dataHeatmapReadModel.ts";
@@ -15,12 +14,12 @@ const DATA_BOOTSTRAP_SNAPSHOT_MAX_BYTES = 256 * 1024;
 export interface DataBootstrapSnapshot {
   createdAtMs: number;
   overviewRangeCacheKey: string;
-  appRangeCacheKey: string;
+  appRangeCacheKey?: string;
   heatmapSelection: HeatmapSelection;
   mappingVersion: number;
   uiLanguage: AppLanguage;
   overviewTrendViewModel: DataTrendViewModel;
-  appTrendViewModel: DataAppTrendViewModel;
+  appTrendViewModel?: DataTrendViewModel;
   heatmapRows: HeatmapWeek[];
   earliestStartTime: number | null;
 }
@@ -51,12 +50,12 @@ function isValidBootstrapSnapshot(value: unknown): value is DataBootstrapSnapsho
   return (
     typeof value.createdAtMs === "number"
     && typeof value.overviewRangeCacheKey === "string"
-    && typeof value.appRangeCacheKey === "string"
+    && (value.appRangeCacheKey === undefined || typeof value.appRangeCacheKey === "string")
     && (typeof value.heatmapSelection === "number" || value.heatmapSelection === "recent")
     && typeof value.mappingVersion === "number"
     && (value.uiLanguage === "zh-CN" || value.uiLanguage === "en-US")
     && isRecord(value.overviewTrendViewModel)
-    && isRecord(value.appTrendViewModel)
+    && (value.appTrendViewModel === undefined || isRecord(value.appTrendViewModel))
     && Array.isArray(value.heatmapRows)
     && (typeof value.earliestStartTime === "number" || value.earliestStartTime === null)
   );

--- a/src/features/data/services/dataFirstScreenPrewarm.ts
+++ b/src/features/data/services/dataFirstScreenPrewarm.ts
@@ -1,6 +1,5 @@
 import type { AppLanguage } from "../../../shared/settings/appSettings.ts";
 import {
-  buildDataAppTrendViewModelFromAggregate,
   buildDataTrendAggregateContext,
   buildDataTrendViewModelFromAggregate,
   prewarmRecentDataHeatmapCache,
@@ -71,12 +70,10 @@ function buildBootstrapSnapshot(
   return {
     createdAtMs: nowMs,
     overviewRangeCacheKey: trendSnapshot.range.cacheKey,
-    appRangeCacheKey: trendSnapshot.range.cacheKey,
     heatmapSelection: "recent",
     mappingVersion: options.mappingVersion,
     uiLanguage: options.uiLanguage,
     overviewTrendViewModel: buildDataTrendViewModelFromAggregate(trendAggregateContext),
-    appTrendViewModel: buildDataAppTrendViewModelFromAggregate(trendAggregateContext, null),
     heatmapRows: buildActivityHeatmap(heatmapSnapshot.sessions, "recent", nowMs),
     earliestStartTime: heatmapSnapshot.earliestStartTime,
   };

--- a/src/features/data/services/dataReadModel.ts
+++ b/src/features/data/services/dataReadModel.ts
@@ -162,7 +162,16 @@ interface MergedDataAppDurationBucket extends DataAppDurationBucket {
   sourceAppKeys: string[];
 }
 
-function buildChartAxis(points: DataTrendPoint[]) {
+export function formatHeatmapDateLabel(dateKey: string) {
+  const date = new Date(`${dateKey}T00:00:00`);
+  return date.toLocaleDateString(getUiLocale(), { month: "2-digit", day: "2-digit" });
+}
+
+function formatHeatmapMonthLabel(date: Date) {
+  return UI_TEXT.date.monthLabel(date.getMonth() + 1);
+}
+
+export function buildChartAxis(points: DataTrendPoint[]) {
   const maxHours = Math.max(0, ...points.map((point) => point.hours));
   const intervalCount = 3;
   const rawStep = Math.max(1, maxHours / intervalCount);
@@ -556,7 +565,7 @@ export function buildDataTrendViewModel(
   nowMs: number,
 ): DataTrendViewModel {
   return buildDataTrendViewModelFromAggregate(
-    buildDataTrendAggregateContext(sessions, selection, nowMs, { includeAppBuckets: false }),
+    buildDataTrendAggregateContext(sessions, selection, nowMs, { includeAppBuckets: true }),
   );
 }
 
@@ -651,16 +660,6 @@ export function buildDataAppTrendViewModel(
     buildDataTrendAggregateContext(sessions, selection, nowMs),
     selectedAppKey,
   );
-}
-
-export function buildDataTrendViewModelsFromAggregate(
-  context: DataTrendAggregateContext,
-  selectedAppKey: string | null,
-) {
-  return {
-    overviewTrendViewModel: buildDataTrendViewModelFromAggregate(context),
-    appTrendViewModel: buildDataAppTrendViewModelFromAggregate(context, selectedAppKey),
-  };
 }
 
 async function resolveDefaultDataHeatmapDependencies(): Promise<DataHeatmapDependencies> {

--- a/tests/dataReadModel.test.ts
+++ b/tests/dataReadModel.test.ts
@@ -74,20 +74,15 @@ function makeBootstrapSnapshot(overrides: Partial<DataBootstrapSnapshot> = {}): 
       endTime: new Date(2026, 4, 8, 10, 0, 0).getTime(),
     }),
   ];
-  const overviewRange = 7;
-  const appRange = 7;
-  const overviewTrendViewModel = buildDataTrendViewModel(sessions, overviewRange, nowMs);
-  const appTrendViewModel = buildDataAppTrendViewModel(sessions, appRange, nowMs, null);
+  const overviewTrendViewModel = buildDataTrendViewModel(sessions, 7, nowMs);
 
   return {
     createdAtMs: nowMs,
     overviewRangeCacheKey: "rolling:7:2026-05-02:2026-05-08",
-    appRangeCacheKey: "rolling:7:2026-05-02:2026-05-08",
     heatmapSelection: "recent",
     mappingVersion: 0,
     uiLanguage: "zh-CN",
     overviewTrendViewModel,
-    appTrendViewModel,
     heatmapRows: buildActivityHeatmap(sessions, "recent", nowMs),
     earliestStartTime: sessions[0].startTime,
     ...overrides,
@@ -673,7 +668,6 @@ await runTest("data first screen prewarm saves a bootstrap snapshot", async () =
 
   assert.equal(snapshot?.mappingVersion, 3);
   assert.equal(savedSnapshot?.overviewTrendViewModel.totalDuration, 60 * 60 * 1000);
-  assert.equal(savedSnapshot?.appTrendViewModel.selectedApp?.appName, "Cursor");
   assert.ok(savedSnapshot?.heatmapRows.length);
 });
 

--- a/tests/uiBrowserSmoke/dataScenarios.ts
+++ b/tests/uiBrowserSmoke/dataScenarios.ts
@@ -264,7 +264,7 @@ export async function runDataScenarios(context: BrowserSmokeContext) {
     assert.equal(
       await evaluate(client!, sessionId, `
         (() => {
-          const trigger = document.querySelectorAll(".data-trend-range-trigger")[1];
+          const trigger = document.querySelector(".data-trend-range-trigger");
           if (!trigger || trigger.textContent?.trim() !== "近 7 天") return false;
           trigger.click();
           return true;
@@ -301,7 +301,7 @@ export async function runDataScenarios(context: BrowserSmokeContext) {
       `),
       true,
     );
-    await waitForExpression(client!, sessionId, `document.querySelectorAll(".data-trend-range-trigger")[1]?.textContent?.trim() === "1天"`);
+    await waitForExpression(client!, sessionId, `document.querySelector(".data-trend-range-trigger")?.textContent?.trim() === "1天"`);
   });
 
   await runTest("data trend chart renders the shared tooltip on real hover", async () => {

--- a/tests/uiSmoke.test.ts
+++ b/tests/uiSmoke.test.ts
@@ -376,7 +376,6 @@ await runTest("Data regular view avoids visible loading and skeleton branches", 
   assert.match(data, /freshReadModelsReady/);
   assert.match(data, /shouldDeferRuntimeReadModels/);
   assert.match(data, /shouldDeferHeatmapRows/);
-  assert.match(data, /EMPTY_DATA_APP_TREND_POINTS/);
 });
 
 await runTest("History regular view avoids visible loading copy", () => {


### PR DESCRIPTION
## Purpose

Remove the standalone `DataAppTrendPanel` and all associated state from the Data page. The app-trend data is folded into the overview trend view-model, simplifying the component tree and preparing the page for the unified detail panel (PR C).

## Accepted Scope
- Project item: Data activity trend enhancement (PR B)

## Changes

- **`Data.tsx`**: Remove `DataAppTrendPanel` import, JSX, and all related state. Drop `icons` from props. Simplify `overviewAggregateContext` to no longer wait for app-trend data.
- **`dataReadModel.ts`**: Remove `buildDataTrendViewModelsFromAggregate`. Change `buildDataTrendViewModel` to pass `includeAppBuckets: true`.
- **`dataBootstrapSnapshot.ts`**: Make `appRangeCacheKey` and `appTrendViewModel` optional.
- **`dataFirstScreenPrewarm.ts`**: Remove `buildDataAppTrendViewModelFromAggregate` import and call.
- **Tests**: Drop app-trend bootstrap assertions, update browser smoke selectors, remove `EMPTY_DATA_APP_TREND_POINTS` check.

## Scope Boundary

- In scope: removing the standalone app trend panel, simplifying Data.tsx state.
- Out of scope: web domain trend, detail panel, chart enhancements, copy changes.
- Out of scope: deleting `DataAppTrendPanel.tsx` (the file remains; removal is handled by PR C).

## Owner Check

- Frontend owner: features/data
- Rust owner: N/A

## Risk Review

- Tracking correctness: N/A
- Local data safety: N/A
- Privacy or security: N/A
- Compatibility and migration: Bootstrap snapshot retains backward compatibility via optional fields.
- Failure and recovery behavior: N/A

## UI Review

- [x] UI follows Quiet Pro — removing a panel and its 270 lines of state is a Quiet Pro simplification.

## Validation

- [x] `npm run check`
- [x] Added focused tests
- `npm run test:data` — passed (30 tests)
- `npm run test:ui-smoke` — passed (49 tests)

## Contributor Checklist

- [x] I read the relevant active project documents under `docs/`.
- [x] This pull request is linked to the Issue or Project item where its scope was agreed.
- [x] This pull request solves one coherent problem.
- [x] Every changed file is necessary for the accepted problem.
- [x] The commits are reviewable.
- [x] New behavior is placed under the correct owner.
- [x] I rebased onto the latest `main`.
- [x] I used `Refs #N` instead of an issue-closing keyword.