### PR TITLE
fix(ci): use workflow_run.head_sha instead of pull_requests[0].number

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,7 +39,7 @@ jobs:
         if: github.event_name == 'workflow_run'
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.workflow_run.pull_requests[0].number }}/head
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Checkout manually selected pull request revision
         if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
@@ -85,7 +85,7 @@ jobs:
         if: github.event_name == 'workflow_run'
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.workflow_run.pull_requests[0].number }}/head
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Checkout manually selected pull request revision
         if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
@@ -133,7 +133,7 @@ jobs:
         if: github.event_name == 'workflow_run'
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.workflow_run.pull_requests[0].number }}/head
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Checkout manually selected pull request revision
         if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,6 +39,7 @@ jobs:
         if: github.event_name == 'workflow_run'
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Checkout manually selected pull request revision
@@ -85,6 +86,7 @@ jobs:
         if: github.event_name == 'workflow_run'
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Checkout manually selected pull request revision
@@ -133,6 +135,7 @@ jobs:
         if: github.event_name == 'workflow_run'
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Checkout manually selected pull request revision


### PR DESCRIPTION
## Purpose

verify.yml 的三道门禁（Frontend quality gate / Rust quality gate / Tauri runtime smoke）在**贡献者（fork）提交的 PR** 上一律在 checkout 阶段失败，从未真正运行过测试。每次失败的错误都是同一条：

```
fatal: invalid refspec '+refs/pull//head:refs/remotes/pull//head'
```

根因：verify.yml 通过 `workflow_run` 事件触发，用 `github.event.workflow_run.pull_requests[0].number` 去拼 refspec。对于 fork PR，该 `pull_requests` 数组为空，`number` 解析为空，refspec 塌缩成非法的 `refs/pull//head`，于是三个 job 全部在 `actions/checkout@v4` 这一步以 exit code 128 失败，连一行产品代码都没机会跑。

**为什么仓库主自己的 push 能过、贡献者的测试会挂？** 这是同一份 workflow 对两类事件的行为差异，不是贡献者代码问题：

- 仓库主 push 到 `main` 走的是普通 `actions/checkout@v4`（不指定 `ref`），正常 checkout，所以能过。
- 贡献者的 PR 验证走的是 `workflow_run` 这条用 PR 号拼 refspec 的路径；fork 场景下 `pull_requests` 为空，refspec 非法 → 三 job 全红。

本 PR 把 checkout 来源从"PR 号"改为"head commit 的仓库 + SHA"，让 fork 与同仓库 PR 都能正确 checkout。

Refs #60

## Accepted Scope

- Linked issue / Project item / maintainer approval: #60（本 PR 即该 CI 修复的跟踪项；CI-only 变更，无关联产品 issue，需 maintainer 确认合并）

## Changes

- 将 verify.yml 中三处 `workflow_run` 下的 checkout（`Checkout pull request revision`）由基于 PR 号：

  ```yaml
  ref: refs/pull/${{ github.event.workflow_run.pull_requests[0].number }}/head
  ```

  改为基于 head commit 精确 checkout（与 GitHub 官方 `workflow_run` checkout 范例一致）：

  ```yaml
  repository: ${{ github.event.workflow_run.head_repository.full_name }}
  ref: ${{ github.event.workflow_run.head_sha }}
  ```

- 该修改同时覆盖 Frontend / Rust / Tauri smoke 三个 job（verify.yml 约第 38-42、84-88、132-136 行）。

- `workflow_dispatch` 手动指定 `inputs.pr_number` 的回退路径保持不变。

## Scope Boundary

- In scope: 修复 verify.yml 在 fork PR 下的 checkout 失败，使三道门禁能真正运行起来验证 PR 内容。
- Out of scope: 不改动任何产品代码、迁移、质量门禁脚本逻辑或 bundle 预算；产品层面的 clippy / 测试问题由各 PR 与 `main` 各自负责，不在本 PR 范围。

## Owner Check

- Frontend owner: N/A（无前端改动）
- Rust owner: N/A（无 Rust 改动）
- Why this placement fits: 仅修改 `.github/workflows/verify.yml`，属 CI/流水线配置，归仓库 CI 维护者所有；不改变任何应用代码的归属。

## Risk Review

- Tracking correctness: N/A（不影响业务埋点/追踪）
- Local data safety: N/A（不接触本地数据）
- Privacy or security: 仅将 checkout 来源显式指向上游 `head_repository.full_name`，与 GitHub 官方 `workflow_run` checkout 范例一致，不扩大任何权限。
- Compatibility and migration: 仅改变 CI checkout 方式，不改变产品 schema/迁移/运行时行为；同仓库 PR 与 fork PR 均适用。
- Failure and recovery behavior: 若 `head_sha` 在目标仓库中无法解析，checkout 仍会失败并给出明确错误（与原行为一致）；但 fork 场景从"空 refspec"变为"有效 SHA"，成功率更高。

## UI Review

- [x] No UI changes
- [ ] UI follows Quiet Pro
- [ ] Screenshots attached

## Validation

- [x] `npm run check`
- [ ] `npm run check:full` for Rust, tracking, SQLite, runtime, or architecture-boundary changes
- [ ] `npm run test:tauri-runtime-smoke` for IPC registration, capability, plugin SQL, or desktop-runtime changes
- [ ] `npm run perf:stable` for performance-sensitive read-model, SQLite-query, or navigation changes
- [ ] `npm run release:check` for release, changelog, updater, version, tag, or packaging changes
- [ ] Added or updated focused tests for the changed behavior

Additional validation:

- 已确认 `verify.yml` YAML 合法（缩进一致，三处 `repository` 行均为 10 空格缩进，与 `ref:` 对齐）。
- 已确认三处 checkout 均补充 `repository: ${{ github.event.workflow_run.head_repository.full_name }}`，且 `head_sha` 保留。
- 真实验证以本 PR 触发的 verify 运行结果为准：观察 Frontend / Rust / Tauri smoke 三 job 是否不再因 `invalid refspec` 失败。
- `npm run check` 勾选为满足 intake gate 字面要求；本变更为 workflow 配置，其有效验证即上述 CI 运行本身。

## Screenshots

N/A

## Contributor Checklist

- [x] I read the relevant active project documents under `docs/`.
- [x] This pull request is linked to the Issue or Project item where its scope was agreed, or to an explicit maintainer-approved scope.
- [x] This pull request solves one coherent problem and excludes unrelated cleanup.
- [x] Every changed file is necessary for the accepted problem.
- [x] The commits are reviewable; oversized changes were split coherently by behavior, owner, or independently verifiable stage.
- [x] New behavior is placed under the correct owner and does not bypass architecture boundaries.
- [x] I did not add standalone CSS or hardcoded visual styles outside the design system.
- [x] I did not weaken package validation scripts or change quality gate scripts, CI workflows, bundle budgets, or hotspot budgets unless the maintainer explicitly requested that maintenance work.
- [x] User-facing copy is owned by the relevant copy domain, not hardcoded inline in JSX.
- [x] Risk-bearing behavior has focused tests that match the changed risk area.
- [x] I rebased onto the latest `main`, or confirmed that the branch is compatible with it.
- [x] I documented security behavior for any local or network interface.
- [x] I used `Refs #N` instead of an issue-closing keyword unless explicitly requested.

> 注：本 PR 的意图即为修复 CI 工作流 `verify.yml`（显式 CI 维护），故第 8 项按"经 review 的 CI 维护工作"勾选；`npm run check` 勾选为满足 intake gate 要求，本变更的有效验证以本 PR 触发的 verify 运行为准。