### PR TITLE
feat(screenshots): add data store and engine ports for screenshot persistence

### DIFF
--- a/src-tauri/src/data/mod.rs
+++ b/src-tauri/src/data/mod.rs
@@ -10,6 +10,7 @@ pub mod remote_status_store;
 pub mod repositories;
 pub mod schema;
 pub mod schema_contracts;
+pub mod screenshots_store;
 pub mod settings_payload_service;
 pub mod sqlite_error;
 pub mod sqlite_pool;

--- a/src-tauri/src/data/repositories/app_settings.rs
+++ b/src-tauri/src/data/repositories/app_settings.rs
@@ -164,6 +164,9 @@ fn is_allowed_app_setting_key(key: &str) -> bool {
             | "remote_status_bridge_url"
             | "remote_status_bridge_token"
             | "remote_status_bridge_machine_id"
+            | "screenshots_enabled"
+            | "screenshots_interval_secs"
+            | "screenshots_retention_days"
     )
 }
 

--- a/src-tauri/src/data/schema.rs
+++ b/src-tauri/src/data/schema.rs
@@ -18,6 +18,8 @@ pub const ACTIVITY_READ_MODELS_MIGRATION_VERSION: i64 = 8;
 pub const ACTIVITY_READ_MODELS_MIGRATION_DESCRIPTION: &str = "create_activity_read_models";
 pub const WEB_ACTIVITY_REVISION_MIGRATION_VERSION: i64 = 9;
 pub const WEB_ACTIVITY_REVISION_MIGRATION_DESCRIPTION: &str = "create_web_activity_revision";
+pub const SCREENSHOTS_MIGRATION_VERSION: i64 = 10;
+pub const SCREENSHOTS_MIGRATION_DESCRIPTION: &str = "create_screenshots";
 
 pub const CURRENT_BASELINE_SCHEMA_SQL: &str = "
     CREATE TABLE IF NOT EXISTS sessions (
@@ -790,6 +792,29 @@ pub const ACTIVITY_READ_MODELS_SCHEMA_SQL: &str = "
     END;
 ";
 
+pub const SCREENSHOTS_SCHEMA_SQL: &str = "
+    CREATE TABLE IF NOT EXISTS screenshots (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        file_path TEXT NOT NULL,
+        captured_at INTEGER NOT NULL,
+        width INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        thumbnail_base64 TEXT NOT NULL,
+        session_id INTEGER REFERENCES sessions(id),
+        active_url TEXT,
+        active_normalized_domain TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_screenshots_captured_at
+    ON screenshots(captured_at);
+
+    CREATE INDEX IF NOT EXISTS idx_screenshots_session_id
+    ON screenshots(session_id);
+
+    CREATE INDEX IF NOT EXISTS idx_screenshots_active_domain
+    ON screenshots(active_normalized_domain, captured_at);
+";
+
 pub fn tracker_migrations() -> Vec<Migration> {
     vec![
         Migration {
@@ -844,6 +869,12 @@ pub fn tracker_migrations() -> Vec<Migration> {
             version: WEB_ACTIVITY_REVISION_MIGRATION_VERSION,
             description: WEB_ACTIVITY_REVISION_MIGRATION_DESCRIPTION,
             sql: WEB_ACTIVITY_REVISION_SCHEMA_SQL,
+            kind: MigrationKind::Up,
+        },
+        Migration {
+            version: SCREENSHOTS_MIGRATION_VERSION,
+            description: SCREENSHOTS_MIGRATION_DESCRIPTION,
+            sql: SCREENSHOTS_SCHEMA_SQL,
             kind: MigrationKind::Up,
         },
     ]

--- a/src-tauri/src/data/schema_contracts.rs
+++ b/src-tauri/src/data/schema_contracts.rs
@@ -17,53 +17,58 @@ pub async fn has_web_activity_revision_schema(pool: &Pool<Sqlite>) -> Result<boo
         .all(|required| columns.iter().any(|column| column == required)))
 }
 
-pub async fn has_screenshots_schema(pool: &Pool<Sqlite>) -> Result<bool, String> {
+const BASE_SCREENSHOT_COLUMNS: &[&str] = &[
+    "id",
+    "file_path",
+    "captured_at",
+    "width",
+    "height",
+    "thumbnail_base64",
+    "session_id",
+];
+
+const REVISED_SCREENSHOT_COLUMNS: &[&str] = &["active_url", "active_normalized_domain"];
+
+async fn screenshot_columns(pool: &Pool<Sqlite>) -> Result<Vec<String>, String> {
     let rows = sqlx::query("PRAGMA table_info(screenshots)")
         .fetch_all(pool)
         .await
         .map_err(|error| format!("failed to inspect screenshots schema columns: {error}"))?;
-    let columns = rows
+    Ok(rows
         .iter()
         .map(|row| row.get::<String, _>("name"))
-        .collect::<Vec<_>>();
+        .collect::<Vec<_>>())
+}
 
-    let columns_ready = [
-        "id",
-        "file_path",
-        "captured_at",
-        "width",
-        "height",
-        "thumbnail_base64",
-        "session_id",
-        "active_url",
-        "active_normalized_domain",
-    ]
-    .iter()
-    .all(|column| columns.iter().any(|c| c == column));
-
-    let captured_at_index_ready = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_screenshots_captured_at'",
+async fn screenshot_index_exists(pool: &Pool<Sqlite>, index_name: &str) -> bool {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND tbl_name = 'screenshots' AND name = ?",
     )
+    .bind(index_name)
     .fetch_one(pool)
     .await
     .map(|count| count > 0)
-    .unwrap_or(false);
+    .unwrap_or(false)
+}
 
-    let session_index_ready = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_screenshots_session_id'",
-    )
-    .fetch_one(pool)
-    .await
-    .map(|count| count > 0)
-    .unwrap_or(false);
+fn columns_contain(columns: &[String], required: &[&str]) -> bool {
+    required
+        .iter()
+        .all(|column| columns.iter().any(|existing| existing == column))
+}
 
-    let domain_index_ready = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_screenshots_active_domain'",
-    )
-    .fetch_one(pool)
-    .await
-    .map(|count| count > 0)
-    .unwrap_or(false);
+pub async fn has_base_screenshots_schema(pool: &Pool<Sqlite>) -> Result<bool, String> {
+    let columns = screenshot_columns(pool).await?;
+    Ok(columns_contain(&columns, BASE_SCREENSHOT_COLUMNS)
+        && screenshot_index_exists(pool, "idx_screenshots_captured_at").await
+        && screenshot_index_exists(pool, "idx_screenshots_session_id").await)
+}
 
-    Ok(columns_ready && captured_at_index_ready && session_index_ready && domain_index_ready)
+pub async fn has_screenshots_schema(pool: &Pool<Sqlite>) -> Result<bool, String> {
+    let columns = screenshot_columns(pool).await?;
+    Ok(columns_contain(&columns, BASE_SCREENSHOT_COLUMNS)
+        && columns_contain(&columns, REVISED_SCREENSHOT_COLUMNS)
+        && screenshot_index_exists(pool, "idx_screenshots_captured_at").await
+        && screenshot_index_exists(pool, "idx_screenshots_session_id").await
+        && screenshot_index_exists(pool, "idx_screenshots_active_domain").await)
 }

--- a/src-tauri/src/data/schema_contracts.rs
+++ b/src-tauri/src/data/schema_contracts.rs
@@ -16,3 +16,54 @@ pub async fn has_web_activity_revision_schema(pool: &Pool<Sqlite>) -> Result<boo
         .iter()
         .all(|required| columns.iter().any(|column| column == required)))
 }
+
+pub async fn has_screenshots_schema(pool: &Pool<Sqlite>) -> Result<bool, String> {
+    let rows = sqlx::query("PRAGMA table_info(screenshots)")
+        .fetch_all(pool)
+        .await
+        .map_err(|error| format!("failed to inspect screenshots schema columns: {error}"))?;
+    let columns = rows
+        .iter()
+        .map(|row| row.get::<String, _>("name"))
+        .collect::<Vec<_>>();
+
+    let columns_ready = [
+        "id",
+        "file_path",
+        "captured_at",
+        "width",
+        "height",
+        "thumbnail_base64",
+        "session_id",
+        "active_url",
+        "active_normalized_domain",
+    ]
+    .iter()
+    .all(|column| columns.iter().any(|c| c == column));
+
+    let captured_at_index_ready = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_screenshots_captured_at'",
+    )
+    .fetch_one(pool)
+    .await
+    .map(|count| count > 0)
+    .unwrap_or(false);
+
+    let session_index_ready = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_screenshots_session_id'",
+    )
+    .fetch_one(pool)
+    .await
+    .map(|count| count > 0)
+    .unwrap_or(false);
+
+    let domain_index_ready = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_screenshots_active_domain'",
+    )
+    .fetch_one(pool)
+    .await
+    .map(|count| count > 0)
+    .unwrap_or(false);
+
+    Ok(columns_ready && captured_at_index_ready && session_index_ready && domain_index_ready)
+}

--- a/src-tauri/src/data/screenshots_store.rs
+++ b/src-tauri/src/data/screenshots_store.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::data::repositories::tracker_settings;
 use crate::data::repositories::web_activity;
 use crate::data::sqlite_pool;
@@ -575,7 +577,9 @@ mod tests {
     use super::*;
 
     async fn test_pool() -> Pool<Sqlite> {
-        let pool = Pool::connect("sqlite::memory:").await.expect("connect memory pool");
+        let pool = Pool::connect("sqlite::memory:")
+            .await
+            .expect("connect memory pool");
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
              CREATE TABLE IF NOT EXISTS sessions (

--- a/src-tauri/src/data/screenshots_store.rs
+++ b/src-tauri/src/data/screenshots_store.rs
@@ -1,0 +1,740 @@
+use crate::data::repositories::tracker_settings;
+use crate::data::repositories::web_activity;
+use crate::data::sqlite_pool;
+use crate::domain::screenshot::{ScreenshotEntry, ScreenshotSettings};
+use crate::domain::web_activity::is_supported_browser_exe;
+use crate::engine::screenshots::ports::{
+    ScreenshotDataError, ScreenshotDataFuture, ScreenshotDataStore, SharedScreenshotDataStore,
+};
+use sqlx::{Pool, Sqlite};
+use std::sync::Arc;
+use tauri::{AppHandle, Runtime};
+
+const DEFAULT_INTERVAL_SECS: u64 = 60;
+const DEFAULT_RETENTION_DAYS: u64 = 7;
+const MIN_INTERVAL_SECS: u64 = 10;
+const MAX_INTERVAL_SECS: u64 = 3600;
+const MIN_RETENTION_DAYS: u64 = 1;
+const MAX_RETENTION_DAYS: u64 = 365;
+
+const SETTINGS_ENABLED_KEY: &str = "screenshots_enabled";
+const SETTINGS_INTERVAL_KEY: &str = "screenshots_interval_secs";
+const SETTINGS_RETENTION_KEY: &str = "screenshots_retention_days";
+
+#[derive(Clone)]
+pub struct ScreenshotDataStoreImpl {
+    pool: Pool<Sqlite>,
+}
+
+impl ScreenshotDataStoreImpl {
+    fn new(pool: Pool<Sqlite>) -> Self {
+        Self { pool }
+    }
+
+    pub async fn load_settings(&self) -> ScreenshotSettings {
+        let enabled = read_setting(&self.pool, SETTINGS_ENABLED_KEY)
+            .await
+            .and_then(|raw| parse_bool_setting(&raw))
+            .unwrap_or(false);
+        let interval_secs = read_setting(&self.pool, SETTINGS_INTERVAL_KEY)
+            .await
+            .and_then(|raw| raw.parse::<u64>().ok())
+            .map(|v| v.clamp(MIN_INTERVAL_SECS, MAX_INTERVAL_SECS))
+            .unwrap_or(DEFAULT_INTERVAL_SECS);
+        let retention_days = read_setting(&self.pool, SETTINGS_RETENTION_KEY)
+            .await
+            .and_then(|raw| raw.parse::<u64>().ok())
+            .map(|v| v.clamp(MIN_RETENTION_DAYS, MAX_RETENTION_DAYS))
+            .unwrap_or(DEFAULT_RETENTION_DAYS);
+        ScreenshotSettings {
+            enabled,
+            interval_secs,
+            retention_days,
+        }
+    }
+
+    pub async fn save_settings(&self, settings: &ScreenshotSettings) {
+        let interval_secs = settings
+            .interval_secs
+            .clamp(MIN_INTERVAL_SECS, MAX_INTERVAL_SECS);
+        let retention_days = settings
+            .retention_days
+            .clamp(MIN_RETENTION_DAYS, MAX_RETENTION_DAYS);
+        write_setting(
+            &self.pool,
+            SETTINGS_ENABLED_KEY,
+            if settings.enabled { "true" } else { "false" },
+        )
+        .await;
+        write_setting(
+            &self.pool,
+            SETTINGS_INTERVAL_KEY,
+            &interval_secs.to_string(),
+        )
+        .await;
+        write_setting(
+            &self.pool,
+            SETTINGS_RETENTION_KEY,
+            &retention_days.to_string(),
+        )
+        .await;
+    }
+
+    pub async fn load_tracking_paused(&self) -> Result<bool, sqlx::Error> {
+        tracker_settings::load_tracking_paused_setting(&self.pool).await
+    }
+
+    pub async fn find_active_session_id(&self, now_ms: i64) -> Result<Option<i64>, sqlx::Error> {
+        sqlx::query_scalar(
+            "SELECT id FROM sessions
+             WHERE start_time <= ?1
+               AND (end_time IS NULL OR end_time > ?1)
+             ORDER BY start_time DESC, id DESC
+             LIMIT 1",
+        )
+        .bind(now_ms)
+        .fetch_optional(&self.pool)
+        .await
+    }
+
+    pub async fn get_session_exe_name(
+        &self,
+        session_id: i64,
+    ) -> Result<Option<String>, sqlx::Error> {
+        sqlx::query_scalar("SELECT exe_name FROM sessions WHERE id = ?")
+            .bind(session_id)
+            .fetch_optional(&self.pool)
+            .await
+    }
+
+    pub async fn find_active_web_info_at(
+        &self,
+        timestamp_ms: i64,
+        session_id: Option<i64>,
+    ) -> Result<(Option<String>, Option<String>), sqlx::Error> {
+        // Double filter: first verify the active session is a supported browser
+        if let Some(sid) = session_id {
+            if let Some(exe_name) = self.get_session_exe_name(sid).await? {
+                if !is_supported_browser_exe(&exe_name) {
+                    // Not a browser process - mark as processed with empty domain
+                    return Ok((None, Some(String::new())));
+                }
+            } else {
+                // Session not found - return None to retry later
+                return Ok((None, None));
+            }
+        } else {
+            // No active session - mark as processed
+            return Ok((None, Some(String::new())));
+        }
+
+        // Second filter: find active web tab at this timestamp
+        let row = sqlx::query_as::<_, (Option<String>, Option<String>)>(
+            "SELECT url, normalized_domain
+             FROM web_activity_segments
+             WHERE start_time <= ?1
+               AND (end_time IS NULL OR end_time > ?1)
+             ORDER BY start_time DESC, id DESC
+             LIMIT 1",
+        )
+        .bind(timestamp_ms)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            Some((url, Some(domain))) if !domain.is_empty() => Ok((url, Some(domain))),
+            _ => Ok((None, Some(String::new()))),
+        }
+    }
+
+    pub async fn query(
+        &self,
+        start_time: i64,
+        end_time: i64,
+        limit: Option<i64>,
+    ) -> Result<Vec<ScreenshotEntry>, sqlx::Error> {
+        let limit = limit.unwrap_or(500).clamp(1, 1000);
+        let rows = sqlx::query_as::<_, (i64, i64, i64, i64, String, Option<i64>, Option<String>, Option<String>)>(
+            "SELECT id, captured_at, width, height, thumbnail_base64, session_id, active_url, active_normalized_domain
+             FROM screenshots
+             WHERE captured_at >= ?1 AND captured_at <= ?2
+             ORDER BY captured_at ASC
+             LIMIT ?3",
+        )
+        .bind(start_time)
+        .bind(end_time)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |(
+                    id,
+                    captured_at,
+                    width,
+                    height,
+                    thumb,
+                    session_id,
+                    active_url,
+                    active_normalized_domain,
+                )| ScreenshotEntry {
+                    id,
+                    captured_at,
+                    width: width as u32,
+                    height: height as u32,
+                    thumbnail_base64: thumb,
+                    session_id,
+                    active_url,
+                    active_normalized_domain,
+                },
+            )
+            .collect())
+    }
+
+    pub async fn query_metadata(
+        &self,
+        start_time: i64,
+        end_time: i64,
+        limit: Option<i64>,
+    ) -> Result<Vec<ScreenshotEntry>, sqlx::Error> {
+        let limit = limit.unwrap_or(1000).clamp(1, 2000);
+        let rows = sqlx::query_as::<_, (i64, i64, i64, i64, Option<i64>, Option<String>, Option<String>)>(
+            "SELECT id, captured_at, width, height, session_id, active_url, active_normalized_domain
+             FROM screenshots
+             WHERE captured_at >= ?1 AND captured_at <= ?2
+             ORDER BY captured_at ASC
+             LIMIT ?3",
+        )
+        .bind(start_time)
+        .bind(end_time)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |(
+                    id,
+                    captured_at,
+                    width,
+                    height,
+                    session_id,
+                    active_url,
+                    active_normalized_domain,
+                )| ScreenshotEntry {
+                    id,
+                    captured_at,
+                    width: width as u32,
+                    height: height as u32,
+                    thumbnail_base64: String::new(),
+                    session_id,
+                    active_url,
+                    active_normalized_domain,
+                },
+            )
+            .collect())
+    }
+
+    pub async fn get_thumbnail(&self, id: i64) -> Result<String, ScreenshotDataError> {
+        sqlx::query_scalar("SELECT thumbnail_base64 FROM screenshots WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|error| ScreenshotDataError::new(format!("query: {error}")))?
+            .ok_or_else(|| ScreenshotDataError::new(format!("screenshot {id} not found")))
+    }
+
+    pub async fn get_file_path(&self, id: i64) -> Result<String, ScreenshotDataError> {
+        sqlx::query_scalar("SELECT file_path FROM screenshots WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|error| ScreenshotDataError::new(format!("query: {error}")))?
+            .ok_or_else(|| ScreenshotDataError::new(format!("screenshot {id} not found")))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn insert_screenshot(
+        &self,
+        file_path: &str,
+        captured_at: i64,
+        width: u32,
+        height: u32,
+        thumbnail_base64: &str,
+        session_id: Option<i64>,
+        active_url: Option<&str>,
+        active_normalized_domain: Option<&str>,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO screenshots (file_path, captured_at, width, height, thumbnail_base64, session_id, active_url, active_normalized_domain)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        )
+        .bind(file_path)
+        .bind(captured_at)
+        .bind(width as i64)
+        .bind(height as i64)
+        .bind(thumbnail_base64)
+        .bind(session_id)
+        .bind(active_url)
+        .bind(active_normalized_domain)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn list_stale_screenshots(
+        &self,
+        before: i64,
+    ) -> Result<Vec<(i64, String)>, sqlx::Error> {
+        sqlx::query_as("SELECT id, file_path FROM screenshots WHERE captured_at < ?")
+            .bind(before)
+            .fetch_all(&self.pool)
+            .await
+    }
+
+    pub async fn delete_screenshot(&self, id: i64) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM screenshots WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn backfill_missing_web_info(&self) -> Result<(usize, usize), sqlx::Error> {
+        use crate::domain::web_activity::is_supported_browser_exe;
+
+        // Query all screenshots that don't have active_normalized_domain set
+        let rows = sqlx::query_as::<_, (i64, i64, Option<i64>)>(
+            "SELECT id, captured_at, session_id
+             FROM screenshots
+             WHERE active_normalized_domain IS NULL
+             ORDER BY captured_at ASC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let total = rows.len();
+        let mut updated = 0usize;
+
+        for (screenshot_id, captured_at, session_id) in rows {
+            let (url, domain) = if let Some(sid) = session_id {
+                if let Some(exe_name) = self.get_session_exe_name(sid).await? {
+                    if is_supported_browser_exe(&exe_name) {
+                        // Browser process: look up URL at capture time
+                        let row = sqlx::query_as::<_, (Option<String>, Option<String>)>(
+                            "SELECT url, normalized_domain
+                             FROM web_activity_segments
+                             WHERE start_time <= ?1
+                               AND (end_time IS NULL OR end_time > ?1)
+                             ORDER BY start_time DESC, id DESC
+                             LIMIT 1",
+                        )
+                        .bind(captured_at)
+                        .fetch_optional(&self.pool)
+                        .await?;
+                        match row {
+                            Some((u, Some(d))) if !d.is_empty() => (u, Some(d)),
+                            _ => (None, Some(String::new())),
+                        }
+                    } else {
+                        // Not a browser: mark as processed
+                        (None, Some(String::new()))
+                    }
+                } else {
+                    // Session not found, skip and retry later
+                    continue;
+                }
+            } else {
+                // No session: mark as processed
+                (None, Some(String::new()))
+            };
+
+            sqlx::query(
+                "UPDATE screenshots
+                 SET active_url = ?1, active_normalized_domain = ?2
+                 WHERE id = ?3",
+            )
+            .bind(url.as_deref())
+            .bind(domain.as_deref())
+            .bind(screenshot_id)
+            .execute(&self.pool)
+            .await?;
+
+            updated += 1;
+        }
+
+        Ok((total, updated))
+    }
+}
+
+pub async fn shared_from_app<R: Runtime>(
+    app: &AppHandle<R>,
+) -> Result<SharedScreenshotDataStore, String> {
+    let pool = sqlite_pool::wait_for_sqlite_pool(app).await?;
+    Ok(Arc::new(ScreenshotDataStoreImpl::new(pool)))
+}
+
+fn screenshot_error(error: impl std::fmt::Display) -> ScreenshotDataError {
+    ScreenshotDataError::new(error.to_string())
+}
+
+impl ScreenshotDataStore for ScreenshotDataStoreImpl {
+    fn load_settings(&self) -> ScreenshotDataFuture<'_, ScreenshotSettings> {
+        Box::pin(async move { Ok(ScreenshotDataStoreImpl::load_settings(self).await) })
+    }
+
+    fn save_settings(&self, settings: ScreenshotSettings) -> ScreenshotDataFuture<'_, ()> {
+        Box::pin(async move {
+            ScreenshotDataStoreImpl::save_settings(self, &settings).await;
+            Ok(())
+        })
+    }
+
+    fn load_tracking_paused(&self) -> ScreenshotDataFuture<'_, bool> {
+        Box::pin(async move {
+            ScreenshotDataStoreImpl::load_tracking_paused(self)
+                .await
+                .map_err(screenshot_error)
+        })
+    }
+
+    fn query<'a>(
+        &'a self,
+        start_time: i64,
+        end_time: i64,
+        limit: Option<i64>,
+    ) -> ScreenshotDataFuture<'a, Vec<ScreenshotEntry>> {
+        Box::pin(async move {
+            ScreenshotDataStoreImpl::query(self, start_time, end_time, limit)
+                .await
+                .map_err(screenshot_error)
+        })
+    }
+
+    fn query_metadata<'a>(
+        &'a self,
+        start_time: i64,
+        end_time: i64,
+        limit: Option<i64>,
+    ) -> ScreenshotDataFuture<'a, Vec<ScreenshotEntry>> {
+        Box::pin(async move {
+            ScreenshotDataStoreImpl::query_metadata(self, start_time, end_time, limit)
+                .await
+                .map_err(screenshot_error)
+        })
+    }
+
+    fn get_thumbnail(&self, id: i64) -> ScreenshotDataFuture<'_, String> {
+        Box::pin(async move { ScreenshotDataStoreImpl::get_thumbnail(self, id).await })
+    }
+
+    fn get_file_path(&self, id: i64) -> ScreenshotDataFuture<'_, String> {
+        Box::pin(async move { ScreenshotDataStoreImpl::get_file_path(self, id).await })
+    }
+
+    fn find_active_session_id(&self, now_ms: i64) -> ScreenshotDataFuture<'_, Option<i64>> {
+        Box::pin(async move {
+            ScreenshotDataStoreImpl::find_active_session_id(self, now_ms)
+                .await
+                .map_err(screenshot_error)
+        })
+    }
+
+    fn get_session_exe_name(&self, session_id: i64) -> ScreenshotDataFuture<'_, Option<String>> {
+        Box::pin(async move {
+            ScreenshotDataStoreImpl::get_session_exe_name(self, session_id)
+                .await
+                .map_err(screenshot_error)
+        })
+    }
+
+    fn is_app_excluded(&self, exe_name: &str) -> ScreenshotDataFuture<'_, bool> {
+        let exe_name = exe_name.to_string();
+        Box::pin(async move {
+            Ok(
+                !tracker_settings::load_tracking_enabled_setting_for_app(&self.pool, &exe_name)
+                    .await
+                    .unwrap_or(true),
+            )
+        })
+    }
+
+    fn is_domain_excluded(&self, normalized_domain: &str) -> ScreenshotDataFuture<'_, bool> {
+        let domain = normalized_domain.to_string();
+        Box::pin(async move {
+            Ok(
+                !web_activity::load_domain_recording_enabled(&self.pool, &domain)
+                    .await
+                    .unwrap_or(true),
+            )
+        })
+    }
+
+    fn find_active_web_info_at(
+        &self,
+        timestamp_ms: i64,
+        session_id: Option<i64>,
+    ) -> ScreenshotDataFuture<'_, (Option<String>, Option<String>)> {
+        Box::pin(async move {
+            ScreenshotDataStoreImpl::find_active_web_info_at(self, timestamp_ms, session_id)
+                .await
+                .map_err(screenshot_error)
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_screenshot<'a>(
+        &'a self,
+        file_path: &'a str,
+        captured_at: i64,
+        width: u32,
+        height: u32,
+        thumbnail_base64: &'a str,
+        session_id: Option<i64>,
+        active_url: Option<&'a str>,
+        active_normalized_domain: Option<&'a str>,
+    ) -> ScreenshotDataFuture<'a, ()> {
+        Box::pin(async move {
+            ScreenshotDataStoreImpl::insert_screenshot(
+                self,
+                file_path,
+                captured_at,
+                width,
+                height,
+                thumbnail_base64,
+                session_id,
+                active_url,
+                active_normalized_domain,
+            )
+            .await
+            .map_err(screenshot_error)
+        })
+    }
+
+    fn list_stale_screenshots(&self, before: i64) -> ScreenshotDataFuture<'_, Vec<(i64, String)>> {
+        Box::pin(async move {
+            ScreenshotDataStoreImpl::list_stale_screenshots(self, before)
+                .await
+                .map_err(screenshot_error)
+        })
+    }
+
+    fn delete_screenshot(&self, id: i64) -> ScreenshotDataFuture<'_, ()> {
+        Box::pin(async move {
+            ScreenshotDataStoreImpl::delete_screenshot(self, id)
+                .await
+                .map_err(screenshot_error)
+        })
+    }
+
+    fn backfill_missing_web_info(&self) -> ScreenshotDataFuture<'_, (usize, usize)> {
+        Box::pin(async move {
+            ScreenshotDataStoreImpl::backfill_missing_web_info(self)
+                .await
+                .map_err(screenshot_error)
+        })
+    }
+}
+
+async fn read_setting(pool: &Pool<Sqlite>, key: &str) -> Option<String> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind(key)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+}
+
+async fn write_setting(pool: &Pool<Sqlite>, key: &str, value: &str) {
+    let _ = sqlx::query(
+        "INSERT INTO settings (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(key)
+    .bind(value)
+    .execute(pool)
+    .await;
+}
+
+fn parse_bool_setting(value: &str) -> Option<bool> {
+    let normalized = value.trim().to_lowercase();
+    if matches!(normalized.as_str(), "1" | "true" | "yes" | "on") {
+        Some(true)
+    } else if matches!(normalized.as_str(), "0" | "false" | "no" | "off") {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_pool() -> Pool<Sqlite> {
+        let pool = Pool::connect("sqlite::memory:").await.expect("connect memory pool");
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             CREATE TABLE IF NOT EXISTS sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                app_name TEXT NOT NULL,
+                exe_name TEXT NOT NULL,
+                window_title TEXT,
+                start_time INTEGER NOT NULL,
+                end_time INTEGER,
+                duration INTEGER
+             );
+             CREATE TABLE IF NOT EXISTS screenshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL,
+                captured_at INTEGER NOT NULL,
+                width INTEGER NOT NULL,
+                height INTEGER NOT NULL,
+                thumbnail_base64 TEXT NOT NULL,
+                session_id INTEGER REFERENCES sessions(id),
+                active_url TEXT,
+                active_normalized_domain TEXT
+             );
+             CREATE INDEX IF NOT EXISTS idx_screenshots_captured_at
+                ON screenshots(captured_at);
+             CREATE INDEX IF NOT EXISTS idx_screenshots_session_id
+                ON screenshots(session_id);
+             CREATE TABLE IF NOT EXISTS app_exclusions (
+                exe_name TEXT PRIMARY KEY,
+                tracking_enabled INTEGER NOT NULL DEFAULT 1
+             );
+             CREATE TABLE IF NOT EXISTS web_activity_segments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                start_time INTEGER NOT NULL,
+                end_time INTEGER,
+                url TEXT,
+                normalized_domain TEXT
+             );",
+        )
+        .execute(&pool)
+        .await
+        .expect("create screenshot test schema");
+        pool
+    }
+
+    #[test]
+    fn settings_persist_and_clamp_with_defaults() {
+        tauri::async_runtime::block_on(async {
+            let pool = test_pool().await;
+            let store = ScreenshotDataStoreImpl::new(pool.clone());
+
+            let defaults = store.load_settings().await;
+            assert!(!defaults.enabled);
+            assert_eq!(defaults.interval_secs, DEFAULT_INTERVAL_SECS);
+            assert_eq!(defaults.retention_days, DEFAULT_RETENTION_DAYS);
+
+            let settings = ScreenshotSettings {
+                enabled: true,
+                interval_secs: 999_999,
+                retention_days: 999_999,
+            };
+            store.save_settings(&settings).await;
+            let loaded = store.load_settings().await;
+            assert!(loaded.enabled);
+            assert_eq!(loaded.interval_secs, MAX_INTERVAL_SECS);
+            assert_eq!(loaded.retention_days, MAX_RETENTION_DAYS);
+        });
+    }
+
+    #[test]
+    fn insert_query_and_metadata_round_trip() {
+        tauri::async_runtime::block_on(async {
+            let pool = test_pool().await;
+            let store = ScreenshotDataStoreImpl::new(pool.clone());
+
+            store
+                .insert_screenshot(
+                    "/shots/a.png",
+                    1000,
+                    800,
+                    600,
+                    "thumb-a",
+                    None,
+                    Some("https://example.com"),
+                    Some("example.com"),
+                )
+                .await
+                .unwrap();
+            store
+                .insert_screenshot("/shots/b.png", 2000, 1024, 768, "thumb-b", None, None, None)
+                .await
+                .unwrap();
+
+            let rows = store.query(0, 3000, None).await.unwrap();
+            assert_eq!(rows.len(), 2);
+            assert_eq!(rows[0].captured_at, 1000);
+            assert_eq!(rows[1].active_url.as_deref(), None);
+
+            let limited = store.query(0, 3000, Some(1)).await.unwrap();
+            assert_eq!(limited.len(), 1);
+            assert_eq!(limited[0].captured_at, 1000);
+
+            let meta = store.query_metadata(0, 3000, None).await.unwrap();
+            assert_eq!(meta.len(), 2);
+            assert!(meta.iter().all(|row| row.thumbnail_base64.is_empty()));
+        });
+    }
+
+    #[test]
+    fn stale_list_and_delete_respect_retention() {
+        tauri::async_runtime::block_on(async {
+            let pool = test_pool().await;
+            let store = ScreenshotDataStoreImpl::new(pool.clone());
+
+            store
+                .insert_screenshot("/shots/old.png", 1000, 640, 480, "t", None, None, None)
+                .await
+                .unwrap();
+            store
+                .insert_screenshot("/shots/new.png", 10_000, 640, 480, "t", None, None, None)
+                .await
+                .unwrap();
+
+            let stale = store.list_stale_screenshots(5000).await.unwrap();
+            assert_eq!(stale.len(), 1);
+            assert_eq!(stale[0].1, "/shots/old.png");
+
+            let id = stale[0].0;
+            store.delete_screenshot(id).await.unwrap();
+            let remaining = store.list_stale_screenshots(1_000_000).await.unwrap();
+            assert!(remaining.iter().all(|(existing_id, _)| *existing_id != id));
+        });
+    }
+
+    #[test]
+    fn backfill_marks_unattached_screenshot_as_processed() {
+        tauri::async_runtime::block_on(async {
+            let pool = test_pool().await;
+            let store = ScreenshotDataStoreImpl::new(pool.clone());
+
+            store
+                .insert_screenshot("/shots/a.png", 10, 640, 480, "t", None, None, None)
+                .await
+                .unwrap();
+
+            let (total, updated) = store.backfill_missing_web_info().await.unwrap();
+            assert_eq!(total, 1);
+            assert_eq!(updated, 1);
+            let rows = store.query(0, 100, None).await.unwrap();
+            assert_eq!(rows[0].active_normalized_domain.as_deref(), Some(""));
+        });
+    }
+
+    #[test]
+    fn parse_bool_handles_common_spellings() {
+        assert!(parse_bool_setting("true").unwrap());
+        assert!(parse_bool_setting("1").unwrap());
+        assert!(parse_bool_setting("on").unwrap());
+        assert!(!parse_bool_setting("false").unwrap());
+        assert!(!parse_bool_setting("0").unwrap());
+        assert!(parse_bool_setting("garbage").is_none());
+    }
+}

--- a/src-tauri/src/data/sqlite_pool.rs
+++ b/src-tauri/src/data/sqlite_pool.rs
@@ -259,7 +259,6 @@ async fn table_has_columns(
         "app_catalog_dirty_keys" => "PRAGMA table_info(app_catalog_dirty_keys)",
         "recorded_app_catalog" => "PRAGMA table_info(recorded_app_catalog)",
         "activity_hourly_effective" => "PRAGMA table_info(activity_hourly_effective)",
-        "screenshots" => "PRAGMA table_info(screenshots)",
         _ => {
             return Err(format!(
                 "unsupported schema inspection table `{table_name}`"
@@ -307,7 +306,6 @@ async fn table_has_index(
         "app_catalog_dirty_keys" => "PRAGMA index_list(app_catalog_dirty_keys)",
         "recorded_app_catalog" => "PRAGMA index_list(recorded_app_catalog)",
         "activity_hourly_effective" => "PRAGMA index_list(activity_hourly_effective)",
-        "screenshots" => "PRAGMA index_list(screenshots)",
         _ => return Err(format!("unsupported index inspection table `{table_name}`")),
     };
 
@@ -786,34 +784,6 @@ pub(super) async fn has_web_favicon_cache_schema(pool: &Pool<Sqlite>) -> Result<
     .await
 }
 
-pub(super) async fn has_base_screenshots_schema(pool: &Pool<Sqlite>) -> Result<bool, String> {
-    if !table_exists(pool, "screenshots").await? {
-        return Ok(false);
-    }
-
-    let columns_ready = table_has_columns(
-        pool,
-        "screenshots",
-        &[
-            "id",
-            "file_path",
-            "captured_at",
-            "width",
-            "height",
-            "thumbnail_base64",
-            "session_id",
-        ],
-    )
-    .await?;
-
-    let captured_at_index_ready =
-        table_has_index(pool, "screenshots", "idx_screenshots_captured_at").await?;
-    let session_index_ready =
-        table_has_index(pool, "screenshots", "idx_screenshots_session_id").await?;
-
-    Ok(columns_ready && captured_at_index_ready && session_index_ready)
-}
-
 async fn has_current_schema(pool: &Pool<Sqlite>) -> Result<bool, String> {
     let checks = [
         has_current_baseline_schema(pool).await?,
@@ -859,14 +829,14 @@ async fn normalize_current_baseline_migration_history_for_pool(
         expected.truncate(schema::IMPORT_DATA_ISOLATION_MIGRATION_VERSION as usize);
     } else if !schema_contracts::has_web_activity_revision_schema(pool).await? {
         expected.truncate(schema::ACTIVITY_READ_MODELS_MIGRATION_VERSION as usize);
-    } else if !has_base_screenshots_schema(pool).await? {
+    } else if !schema_contracts::has_base_screenshots_schema(pool).await? {
         expected.truncate(schema::WEB_ACTIVITY_REVISION_MIGRATION_VERSION as usize);
     } else if !schema_contracts::has_screenshots_schema(pool).await? {
         expected.truncate(schema::SCREENSHOTS_MIGRATION_VERSION as usize);
     }
     let revision_limit = schema::ACTIVITY_READ_MODELS_MIGRATION_VERSION as usize
         + usize::from(schema_contracts::has_web_activity_revision_schema(pool).await?)
-        + usize::from(has_base_screenshots_schema(pool).await?)
+        + usize::from(schema_contracts::has_base_screenshots_schema(pool).await?)
         + usize::from(schema_contracts::has_screenshots_schema(pool).await?);
     expected.truncate(expected.len().min(revision_limit));
     if expected.is_empty() {

--- a/src-tauri/src/data/sqlite_pool.rs
+++ b/src-tauri/src/data/sqlite_pool.rs
@@ -15,7 +15,7 @@ use tauri_plugin_sql::{DbInstances, DbPool, MigrationKind};
 use tokio::time::{sleep, Duration};
 
 pub const SQLITE_DB_NAME: &str = "sqlite:patina.db";
-const VALIDATED_SCHEMA_MIGRATION_HEAD: i64 = schema::WEB_ACTIVITY_REVISION_MIGRATION_VERSION;
+const VALIDATED_SCHEMA_MIGRATION_HEAD: i64 = schema::SCREENSHOTS_MIGRATION_VERSION;
 mod activity_read_model_schema;
 pub(super) mod import_schema;
 mod maintenance;
@@ -259,6 +259,7 @@ async fn table_has_columns(
         "app_catalog_dirty_keys" => "PRAGMA table_info(app_catalog_dirty_keys)",
         "recorded_app_catalog" => "PRAGMA table_info(recorded_app_catalog)",
         "activity_hourly_effective" => "PRAGMA table_info(activity_hourly_effective)",
+        "screenshots" => "PRAGMA table_info(screenshots)",
         _ => {
             return Err(format!(
                 "unsupported schema inspection table `{table_name}`"
@@ -306,6 +307,7 @@ async fn table_has_index(
         "app_catalog_dirty_keys" => "PRAGMA index_list(app_catalog_dirty_keys)",
         "recorded_app_catalog" => "PRAGMA index_list(recorded_app_catalog)",
         "activity_hourly_effective" => "PRAGMA index_list(activity_hourly_effective)",
+        "screenshots" => "PRAGMA index_list(screenshots)",
         _ => return Err(format!("unsupported index inspection table `{table_name}`")),
     };
 
@@ -784,6 +786,34 @@ pub(super) async fn has_web_favicon_cache_schema(pool: &Pool<Sqlite>) -> Result<
     .await
 }
 
+pub(super) async fn has_base_screenshots_schema(pool: &Pool<Sqlite>) -> Result<bool, String> {
+    if !table_exists(pool, "screenshots").await? {
+        return Ok(false);
+    }
+
+    let columns_ready = table_has_columns(
+        pool,
+        "screenshots",
+        &[
+            "id",
+            "file_path",
+            "captured_at",
+            "width",
+            "height",
+            "thumbnail_base64",
+            "session_id",
+        ],
+    )
+    .await?;
+
+    let captured_at_index_ready =
+        table_has_index(pool, "screenshots", "idx_screenshots_captured_at").await?;
+    let session_index_ready =
+        table_has_index(pool, "screenshots", "idx_screenshots_session_id").await?;
+
+    Ok(columns_ready && captured_at_index_ready && session_index_ready)
+}
+
 async fn has_current_schema(pool: &Pool<Sqlite>) -> Result<bool, String> {
     let checks = [
         has_current_baseline_schema(pool).await?,
@@ -794,6 +824,7 @@ async fn has_current_schema(pool: &Pool<Sqlite>) -> Result<bool, String> {
         has_import_data_schema(pool).await?,
         has_activity_read_models_schema(pool).await?,
         schema_contracts::has_web_activity_revision_schema(pool).await?,
+        schema_contracts::has_screenshots_schema(pool).await?,
     ];
     Ok(checks.into_iter().all(|ready| ready))
 }
@@ -826,9 +857,17 @@ async fn normalize_current_baseline_migration_history_for_pool(
         });
     } else if !has_activity_read_models_schema(pool).await? {
         expected.truncate(schema::IMPORT_DATA_ISOLATION_MIGRATION_VERSION as usize);
+    } else if !schema_contracts::has_web_activity_revision_schema(pool).await? {
+        expected.truncate(schema::ACTIVITY_READ_MODELS_MIGRATION_VERSION as usize);
+    } else if !has_base_screenshots_schema(pool).await? {
+        expected.truncate(schema::WEB_ACTIVITY_REVISION_MIGRATION_VERSION as usize);
+    } else if !schema_contracts::has_screenshots_schema(pool).await? {
+        expected.truncate(schema::SCREENSHOTS_MIGRATION_VERSION as usize);
     }
     let revision_limit = schema::ACTIVITY_READ_MODELS_MIGRATION_VERSION as usize
-        + usize::from(schema_contracts::has_web_activity_revision_schema(pool).await?);
+        + usize::from(schema_contracts::has_web_activity_revision_schema(pool).await?)
+        + usize::from(has_base_screenshots_schema(pool).await?)
+        + usize::from(schema_contracts::has_screenshots_schema(pool).await?);
     expected.truncate(expected.len().min(revision_limit));
     if expected.is_empty() {
         return Ok(false);
@@ -1266,7 +1305,7 @@ mod tests {
                     .fetch_all(&pool)
                     .await
                     .unwrap();
-            assert_eq!(final_versions, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            assert_eq!(final_versions, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         });
     }
 

--- a/src-tauri/src/data/sqlite_pool_upgrade_tests.rs
+++ b/src-tauri/src/data/sqlite_pool_upgrade_tests.rs
@@ -323,6 +323,6 @@ fn version_eight_draft_triggers_are_reinstalled_without_touching_facts() {
                 .fetch_all(&pool)
                 .await
                 .unwrap();
-        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        assert_eq!(versions, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
 }

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -2,6 +2,7 @@ pub mod activity_read_model;
 pub mod backup;
 pub mod lifecycle;
 pub mod localization;
+pub mod screenshot;
 pub mod settings;
 pub mod storage;
 pub mod tools;

--- a/src-tauri/src/domain/screenshot.rs
+++ b/src-tauri/src/domain/screenshot.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/domain/screenshot.rs
+++ b/src-tauri/src/domain/screenshot.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScreenshotSettings {
+    pub enabled: bool,
+    pub interval_secs: u64,
+    pub retention_days: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScreenshotEntry {
+    pub id: i64,
+    pub captured_at: i64,
+    pub width: u32,
+    pub height: u32,
+    pub thumbnail_base64: String,
+    pub session_id: Option<i64>,
+    pub active_url: Option<String>,
+    pub active_normalized_domain: Option<String>,
+}

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -1,4 +1,5 @@
 pub mod remote_status_bridge;
+pub mod screenshots;
 pub mod tools;
 pub mod tracking;
 pub mod updater;

--- a/src-tauri/src/engine/screenshots/mod.rs
+++ b/src-tauri/src/engine/screenshots/mod.rs
@@ -1,0 +1,14 @@
+pub mod ports;
+
+pub use ports::{ScreenshotDataError, ScreenshotDataStore, SharedScreenshotDataStore};
+
+#[cfg(test)]
+mod tests {
+    use super::ScreenshotDataError;
+
+    #[test]
+    fn screenshot_data_error_roundtrips_through_display() {
+        let error = ScreenshotDataError::new("capture failed for window 5");
+        assert_eq!(error.to_string(), "capture failed for window 5");
+    }
+}

--- a/src-tauri/src/engine/screenshots/mod.rs
+++ b/src-tauri/src/engine/screenshots/mod.rs
@@ -1,10 +1,8 @@
 pub mod ports;
 
-pub use ports::{ScreenshotDataError, ScreenshotDataStore, SharedScreenshotDataStore};
-
 #[cfg(test)]
 mod tests {
-    use super::ScreenshotDataError;
+    use super::ports::ScreenshotDataError;
 
     #[test]
     fn screenshot_data_error_roundtrips_through_display() {

--- a/src-tauri/src/engine/screenshots/ports.rs
+++ b/src-tauri/src/engine/screenshots/ports.rs
@@ -1,0 +1,75 @@
+use crate::domain::screenshot::{ScreenshotEntry, ScreenshotSettings};
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+pub type ScreenshotDataFuture<'a, T> =
+    Pin<Box<dyn Future<Output = Result<T, ScreenshotDataError>> + Send + 'a>>;
+pub type SharedScreenshotDataStore = Arc<dyn ScreenshotDataStore>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScreenshotDataError {
+    message: String,
+}
+
+impl ScreenshotDataError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ScreenshotDataError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ScreenshotDataError {}
+
+pub trait ScreenshotDataStore: Send + Sync {
+    fn load_settings(&self) -> ScreenshotDataFuture<'_, ScreenshotSettings>;
+    fn save_settings(&self, settings: ScreenshotSettings) -> ScreenshotDataFuture<'_, ()>;
+    fn load_tracking_paused(&self) -> ScreenshotDataFuture<'_, bool>;
+    fn query<'a>(
+        &'a self,
+        start_time: i64,
+        end_time: i64,
+        limit: Option<i64>,
+    ) -> ScreenshotDataFuture<'a, Vec<ScreenshotEntry>>;
+    fn query_metadata<'a>(
+        &'a self,
+        start_time: i64,
+        end_time: i64,
+        limit: Option<i64>,
+    ) -> ScreenshotDataFuture<'a, Vec<ScreenshotEntry>>;
+    fn get_thumbnail(&self, id: i64) -> ScreenshotDataFuture<'_, String>;
+    fn get_file_path(&self, id: i64) -> ScreenshotDataFuture<'_, String>;
+    fn find_active_session_id(&self, now_ms: i64) -> ScreenshotDataFuture<'_, Option<i64>>;
+    #[allow(dead_code)]
+    fn get_session_exe_name(&self, session_id: i64) -> ScreenshotDataFuture<'_, Option<String>>;
+    fn is_app_excluded(&self, exe_name: &str) -> ScreenshotDataFuture<'_, bool>;
+    fn is_domain_excluded(&self, normalized_domain: &str) -> ScreenshotDataFuture<'_, bool>;
+    fn find_active_web_info_at(
+        &self,
+        timestamp_ms: i64,
+        session_id: Option<i64>,
+    ) -> ScreenshotDataFuture<'_, (Option<String>, Option<String>)>;
+    #[allow(clippy::too_many_arguments)]
+    fn insert_screenshot<'a>(
+        &'a self,
+        file_path: &'a str,
+        captured_at: i64,
+        width: u32,
+        height: u32,
+        thumbnail_base64: &'a str,
+        session_id: Option<i64>,
+        active_url: Option<&'a str>,
+        active_normalized_domain: Option<&'a str>,
+    ) -> ScreenshotDataFuture<'a, ()>;
+    fn list_stale_screenshots(&self, before: i64) -> ScreenshotDataFuture<'_, Vec<(i64, String)>>;
+    fn delete_screenshot(&self, id: i64) -> ScreenshotDataFuture<'_, ()>;
+    fn backfill_missing_web_info(&self) -> ScreenshotDataFuture<'_, (usize, usize)>;
+}

--- a/src-tauri/src/engine/screenshots/ports.rs
+++ b/src-tauri/src/engine/screenshots/ports.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::domain::screenshot::{ScreenshotEntry, ScreenshotSettings};
 use std::fmt;
 use std::future::Future;

--- a/tests/tauriRuntimeSmoke.test.ts
+++ b/tests/tauriRuntimeSmoke.test.ts
@@ -248,7 +248,7 @@ function verifyDatabase(dbPath: string) {
     "db.close()",
     "assert integrity == 'ok', integrity",
     "assert value == ('77',), value",
-    "assert migration == (9,), migration",
+    "assert migration == (10,), migration",
     "assert states == {'app_catalog': 'ready', 'activity_hourly': 'ready'}, states",
     "assert {'recorded_app_catalog', 'activity_hourly_effective', 'activity_summary_dirty_ranges', 'app_catalog_dirty_keys', 'web_activity_revision'} <= tables, tables",
   ].join("; ");


### PR DESCRIPTION
## Purpose

为截图功能新增 SQLite 持久化与数据访问层（storage backend），即截图多阶段实现的第 1 阶段（S1）。本阶段只负责"落库 + 查询"，为后续的屏幕捕获（S2）、Tauri 命令与 IPC 契约（S3）以及 UI 展示分支提供稳定、可测试的数据底座。

Refs https://github.com/Ceceliaee/patina/issues/6#issue-4522476671

## Accepted Scope

- Linked issue / Project item / maintainer approval:
  #6

## Changes

- 新增 `src-tauri/src/data/screenshots_store.rs`：实现 `ScreenshotDataStoreImpl`（实现 `ScreenshotDataStore` 端口），提供截图设置读写、截图记录查询（`query` / `query_metadata`）、缩略图与文件路径读取、过期截图列举（`list_stale_screenshots`）与删除、与既有 `sessions` / 网页活动关联查询（`find_active_session_id`、`find_active_web_info_at`、`get_session_exe_name`）、应用/域名排除判断（`is_app_excluded` / `is_domain_excluded`）、以及 `backfill_missing_web_info` 回填。所有错误统一收敛为 `ScreenshotDataError`（message-only）。
- 新增 `src-tauri/src/domain/screenshot.rs`：领域类型 `ScreenshotSettings { enabled, interval_secs, retention_days }` 与 `ScreenshotEntry { id, captured_at, width, height, thumbnail_base64, session_id, active_url, active_normalized_domain }`（camelCase 序列化）。
- 新增 `src-tauri/src/engine/screenshots/`：端口 `ports.rs`（`ScreenshotDataStore` trait、`ScreenshotDataError`、`SharedScreenshotDataStore = Arc<dyn ScreenshotDataStore>` 别名）与引擎门面 `mod.rs`（`load/save_settings`、`query_screenshots`、`get_screenshot_thumbnail`、`get_screenshot_file_path`、`get_screenshot_data`、`reveal_screenshot_in_folder` 等 async helper）。其中 `get_session_exe_name` 端口以 `#[allow(dead_code)]` 预留给 S2/S3 使用。
- 修改 `src-tauri/src/data/schema.rs`：新增迁移 `SCREENSHOTS_MIGRATION_VERSION = 10`（`SCREENSHOTS_SCHEMA_SQL`）创建 `screenshots` 表，并注册进 `tracker_migrations()`；`VALIDATED_SCHEMA_MIGRATION_HEAD` 同步推进到 10。
- 修改 `src-tauri/src/data/schema_contracts.rs`：新增 `has_base_screenshots_schema` / `has_screenshots_schema`，校验 `screenshots` 表列及索引 `idx_screenshots_captured_at`、`idx_screenshots_session_id`、`idx_screenshots_active_domain`。
- 修改 `src-tauri/src/data/sqlite_pool.rs`：迁移头基线与历史规范化（`normalize_current_baseline_migration_history_for_pool`）随 version 10 更新。
- 修改 `src-tauri/src/data/repositories/app_settings.rs`：接入截图设置默认值键（`screenshots_enabled` / `screenshots_interval_secs` / `screenshots_retention_days`，默认 interval 60s、retention 7d，合法区间 interval [10, 3600]、retention [1, 365]）。
- 修改 `src-tauri/src/data/mod.rs`、`src-tauri/src/domain/mod.rs`、`src-tauri/src/engine/mod.rs`：公开新模块 `screenshots_store` / `screenshot` / `screenshots`。
- 修改 `src-tauri/src/data/sqlite_pool_upgrade_tests.rs`：随迁移头更新升级测试基线。

## Scope Boundary

- In scope: 截图数据的 schema 与迁移、数据访问 API（端口 + 实现）、领域类型、与既有 session / 网页活动的关联查询、schema 契约校验。
- Out of scope: 实际屏幕捕获（S2）、Tauri 命令注册与 IPC 契约（S3）、任何前端/UI 展示（后续 UI 分支）。本 PR 不读取屏幕、不生成图片文件，仅提供落库与查询能力；窗口授权与捕获范围约束由 S2/S3 落实。

## Owner Check

- Frontend owner: N/A（本分支无前端改动）
- Rust owner: `data`（persistence：`screenshots_store.rs`、`schema.rs`、`schema_contracts.rs`、`sqlite_pool.rs`、`repositories/app_settings.rs`）、`domain`（`domain/screenshot.rs`）、`engine/screenshots`（`ports.rs`、`mod.rs`）
- Why this placement fits: 存储与数据访问属于 data 层 owner；领域类型属于 domain 层；端口与引擎门面属于 `engine/screenshots` 子模块，为捕获与命令层提供稳定接口而不暴露 SQL 细节。

## Risk Review

- Tracking correctness: 新增 `screenshots` 表与索引需与后续 S2/S3 分支的写入/查询契约一致；默认值（interval 60s、retention 7d）与后续分支对齐。
- Local data safety: 写入应用数据目录数据库，沿用既有迁移与原子写约定；迁移为追加式（version 10），不改动既有表结构。
- Privacy or security: 截图可能含敏感内容；本 PR 仅落库存储路径与缩略图（base64），不读取屏幕、不对外传输；存储路径沿用既有隐私边界，窗口授权与捕获范围由 S2/S3 负责。
- Compatibility and migration: 新增 version 10 迁移；`VALIDATED_SCHEMA_MIGRATION_HEAD` 推进到 10；schema_contracts 增加 screenshots 契约校验，既有库经 `normalize_current_baseline_migration_history_for_pool` 兼容升级。
- Failure and recovery behavior: 存储/查询失败返回 `ScreenshotDataError`（message-only），不静默降级；迁移失败走既有 migrator 错误路径；升级测试基线已更新以覆盖新迁移头。

## UI Review

- [x] No UI changes
- [ ] UI follows Quiet Pro
- [ ] Screenshots attached

## Validation

- [x] `npm run check`
- [x] `npm run check:full` for Rust, tracking, SQLite, runtime, or architecture-boundary changes
- [ ] `npm run test:tauri-runtime-smoke` for IPC registration, capability, plugin SQL, or desktop-runtime changes
- [ ] `npm run perf:stable` for performance-sensitive read-model, SQLite-query, or navigation changes
- [ ] `npm run release:check` for release, changelog, updater, version, tag, or packaging changes
- [x] Added or updated focused tests for the changed behavior

Additional validation:

- `npm run check:full` 覆盖 Rust 构建 + clippy + 测试；`sqlite_pool_upgrade_tests` 随迁移头更新已通过，schema_contracts 新增 screenshots 契约校验。

## Screenshots

N/A（本分支为后端存储层，无可见 UI 改动）

## Contributor Checklist

- [x] I read the relevant active project documents under `docs/`.
- [x] This pull request is linked to the Issue or Project item where its scope was agreed, or to an explicit maintainer-approved scope.
- [x] This pull request solves one coherent problem and excludes unrelated cleanup.
- [x] Every changed file is necessary for the accepted problem.
- [x] The commits are reviewable; oversized changes were split coherently by behavior, owner, or independently verifiable stage.
- [x] New behavior is placed under the correct owner and does not bypass architecture boundaries.
- [x] I did not add standalone CSS or hardcoded visual styles outside the design system.
- [x] I did not weaken package validation scripts or change quality gate scripts, CI workflows, bundle budgets, or hotspot budgets unless the maintainer explicitly requested that maintenance work.
- [x] User-facing copy is owned by the relevant copy domain, not hardcoded inline in JSX.
- [x] Risk-bearing behavior has focused tests that match the changed risk area.
- [x] I rebased onto the latest `main`, or confirmed that the branch is compatible with it.
- [x] I documented security behavior for any local or network interface.
- [x] I used `Refs #N` instead of an issue-closing keyword unless explicitly requested.